### PR TITLE
Add Bedrock API route for solar panel image analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# AWS Bedrock credentials for the analyze API route.
+# For local dev: copy this file to .env and fill in values.
+# For production: set via EAS Secrets (eas env:create).
+
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.*
 *.pem
 
 # local env files
+.env
 .env*.local
 
 # typescript
@@ -39,6 +40,13 @@ yarn-error.*
 # generated native folders
 /ios
 /android
+
+# Terraform
+terraform/.terraform/
+terraform/*.tfstate
+terraform/*.tfstate.backup
+terraform/.terraform.lock.hcl
+terraform/backend.hcl
 
 # Claude
 settings.local.json

--- a/README.md
+++ b/README.md
@@ -188,21 +188,32 @@ src/
 ├── app/
 │   ├── _layout.tsx        # Root layout with transparent header
 │   ├── index.tsx          # Home screen with Upload/Custom options
-│   ├── upload.tsx         # Image capture and gallery selection
-│   └── custom.tsx         # Custom canvas editor with toolbar
+│   ├── upload.tsx         # Image capture, analysis, and processing overlay
+│   ├── custom.tsx         # Custom canvas editor with toolbar
+│   └── api/
+│       └── analyze+api.ts # Bedrock API route (Claude vision analysis)
 ├── components/
 │   ├── OptionCard.tsx     # Home screen option cards
 │   ├── ImagePreview.tsx   # Image preview component
 │   ├── PermissionModal.tsx # Camera permission modal
+│   ├── ProcessingOverlay.tsx # Fibonacci shader + shimmer text overlay
 │   ├── SolarPanel.tsx     # Skia panel rendering with rotation
 │   └── SolarPanelCanvas.tsx # Main canvas with gesture handling
 ├── hooks/
 │   ├── useImagePicker.ts  # Camera and gallery picker hook
 │   └── usePanelsManager.ts # Panel state management (CRUD)
 └── utils/
+    ├── analysisStore.ts   # Module-level store for passing analysis results
     ├── collision.ts       # AABB collision detection
     ├── gridSnap.ts        # Grid snapping utilities
+    ├── imageResize.ts     # Client-side image resize for upload
     └── panelUtils.ts      # Panel dimensions, hit testing, positioning
+terraform/
+├── main.tf                # IAM user + Bedrock policy + S3 backend
+├── variables.tf           # AWS region variable
+├── outputs.tf             # Access key outputs
+├── backend.hcl.example    # S3 backend config template
+└── README.md              # Terraform setup instructions
 ```
 
 ---
@@ -216,11 +227,14 @@ src/
 - [x] Add panel rotation (portrait/landscape)
 - [x] Implement infinite canvas with viewport panning
 - [x] Add snap-to-origin button
-- [ ] Integrate AWS Bedrock for image analysis
+- [x] Add processing overlay with fibonacci shader animation
+- [x] Integrate AWS Bedrock for image analysis (Claude Sonnet 4.5)
+- [x] Set up Expo API route for server-side Bedrock calls
+- [x] Add Terraform config for IAM resources
+- [ ] Deploy API routes to EAS Hosting
 - [ ] Implement compass orientation indicator
 - [ ] Create panel detail bottom sheet
 - [ ] Build energy simulation engine
-- [ ] Set up API routes with EAS hosting
 
 ---
 

--- a/app.json
+++ b/app.json
@@ -25,7 +25,7 @@
       "predictiveBackGestureEnabled": false
     },
     "web": {
-      "output": "static",
+      "output": "server",
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [

--- a/bun.lock
+++ b/bun.lock
@@ -4,14 +4,17 @@
     "": {
       "name": "react-native-array-layout-2",
       "dependencies": {
+        "@ai-sdk/amazon-bedrock": "^4.0.50",
         "@expo/vector-icons": "^15.0.3",
-        "@shopify/react-native-skia": "^2.4.18",
+        "@shopify/react-native-skia": "2.4.14",
+        "ai": "^6.0.74",
         "expo": "55.0.0-preview.9",
         "expo-constants": "~55.0.3",
         "expo-dev-client": "~55.0.4",
         "expo-font": "~55.0.3",
         "expo-haptics": "~55.0.4",
         "expo-image": "~55.0.3",
+        "expo-image-manipulator": "~55.0.4",
         "expo-image-picker": "~55.0.4",
         "expo-linking": "~55.0.3",
         "expo-router": "55.0.0-preview.6",
@@ -45,6 +48,22 @@
     "@expo/log-box": "55.0.5",
   },
   "packages": {
+    "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@4.0.50", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.37", "@ai-sdk/provider": "3.0.7", "@ai-sdk/provider-utils": "4.0.13", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-DsIxaUHPbDUY0DfxYMz6GL9tO/z7ISiwACSiYupcYImqrcdLtIGFujPgszOf92ed3olfhjdkhTwKBHaf6Yh6Qw=="],
+
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.37", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@ai-sdk/provider-utils": "4.0.13" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-tEgcJPw+a6obbF+SHrEiZsx3DNxOHqeY8bK4IpiNsZ8YPZD141R34g3lEAaQnmNN5mGsEJ8SXoEDabuzi8wFJQ=="],
+
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.36", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@ai-sdk/provider-utils": "4.0.13", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2r1Q6azvqMYxQ1hqfWZmWg4+8MajoldD/ty65XdhCaCoBfvDu7trcvxXDfTSU+3/wZ1JIDky46SWYFOHnTbsBw=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.1", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -363,6 +382,8 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
@@ -443,13 +464,27 @@
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
-    "@shopify/react-native-skia": ["@shopify/react-native-skia@2.4.18", "", { "dependencies": { "canvaskit-wasm": "0.40.0", "react-reconciler": "0.31.0" }, "peerDependencies": { "react": ">=19.0", "react-native": ">=0.78", "react-native-reanimated": ">=3.19.1" }, "optionalPeers": ["react-native", "react-native-reanimated"], "bin": { "setup-skia-web": "scripts/setup-canvaskit.js" } }, "sha512-/AB/mvb2dGSQVIJTxyG9ZMFn2PjwWlVcFxHU4TV+K25LCU49ntJXl4xda2ghXxdENMggKgO9R5pA+P/AQ0UUrA=="],
+    "@shopify/react-native-skia": ["@shopify/react-native-skia@2.4.14", "", { "dependencies": { "canvaskit-wasm": "0.40.0", "react-reconciler": "0.31.0" }, "peerDependencies": { "react": ">=19.0", "react-native": ">=0.78", "react-native-reanimated": ">=3.19.1" }, "optionalPeers": ["react-native", "react-native-reanimated"], "bin": { "setup-skia-web": "scripts/setup-canvaskit.js" } }, "sha512-zFxjAQbfrdOxoNJoaOCZQzZliuAWXjFkrNZv2PtofG2RAUPWIxWmk2J/oOROpTwXgkmh1JLvFp3uONccTXUthQ=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
     "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
 
     "@sinonjs/fake-timers": ["@sinonjs/fake-timers@10.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.0" } }, "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA=="],
+
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.8", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.12.0", "@smithy/util-hex-encoding": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ=="],
+
+    "@smithy/types": ["@smithy/types@4.12.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew=="],
+
+    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.2.0", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -547,6 +582,8 @@
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
 
+    "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
+
     "@webgpu/types": ["@webgpu/types@0.1.21", "", {}, "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
@@ -560,6 +597,8 @@
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ai": ["ai@6.0.74", "", { "dependencies": { "@ai-sdk/gateway": "3.0.36", "@ai-sdk/provider": "3.0.7", "@ai-sdk/provider-utils": "4.0.13", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-psGKcE4J0WEXZEvZrc6yc4BzGZW4sfMrbXZgYxyL6Mj8eES5oCaoSGEQfYeNdZvj10EEEXr9rsnUAWZdHiQ/DQ=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
@@ -602,6 +641,8 @@
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "babel-jest": ["babel-jest@29.7.0", "", { "dependencies": { "@jest/transform": "^29.7.0", "@types/babel__core": "^7.1.14", "babel-plugin-istanbul": "^6.1.1", "babel-preset-jest": "^29.6.3", "chalk": "^4.0.0", "graceful-fs": "^4.2.9", "slash": "^3.0.0" }, "peerDependencies": { "@babel/core": "^7.8.0" } }, "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg=="],
 
@@ -829,6 +870,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
     "expo": ["expo@55.0.0-preview.9", "", { "dependencies": { "@babel/runtime": "^7.20.0", "@expo/cli": "55.0.6", "@expo/config": "~55.0.4", "@expo/config-plugins": "~55.0.4", "@expo/devtools": "55.0.2", "@expo/fingerprint": "0.16.3", "@expo/local-build-cache-provider": "55.0.3", "@expo/log-box": "55.0.5", "@expo/metro": "~54.2.0", "@expo/metro-config": "55.0.4", "@expo/vector-icons": "^15.0.2", "@ungap/structured-clone": "^1.3.0", "babel-preset-expo": "~55.0.3", "expo-asset": "~55.0.3", "expo-constants": "~55.0.3", "expo-file-system": "~55.0.4", "expo-font": "~55.0.3", "expo-keep-awake": "~55.0.2", "expo-modules-autolinking": "55.0.3", "expo-modules-core": "55.0.7", "pretty-format": "^29.7.0", "react-refresh": "^0.14.2", "whatwg-url-minimum": "^0.1.1" }, "peerDependencies": { "@expo/dom-webview": "*", "@expo/metro-runtime": "*", "react": "*", "react-native": "*", "react-native-webview": "*" }, "optionalPeers": ["@expo/dom-webview", "@expo/metro-runtime", "react-native-webview"], "bin": { "expo": "bin/cli", "expo-modules-autolinking": "bin/autolinking", "fingerprint": "bin/fingerprint" } }, "sha512-/JtS2+U8Yq6wziNXIpG4tFpI4xLYtizlHrDe0biuZTY2UirtDSaCI3fBuGHQXKleUJpKArC9INEzXWLLFOPj+w=="],
 
     "expo-asset": ["expo-asset@55.0.3", "", { "dependencies": { "@expo/image-utils": "^0.8.12", "expo-constants": "~55.0.3" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-24orrYwSJuMvB8BfF+fPexe+Ily2wcgtUgLvb+izuANkP83iECXTXspzRVqo8uPB2EDF3uglnO3b04XQhjUpTQ=="],
@@ -852,6 +895,8 @@
     "expo-image": ["expo-image@55.0.3", "", { "dependencies": { "sf-symbols-typescript": "^2.2.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-u/Mz/5lrzx+Qoo5yklJkPgMSXTEwB5oorhutucE8KSVBaKZMTdU7Tlmiw+hkiA2FSIADT4h2wA2wn6H43vdHxA=="],
 
     "expo-image-loader": ["expo-image-loader@55.0.0", "", { "peerDependencies": { "expo": "*" } }, "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ=="],
+
+    "expo-image-manipulator": ["expo-image-manipulator@55.0.4", "", { "dependencies": { "expo-image-loader": "~55.0.0" }, "peerDependencies": { "expo": "*" } }, "sha512-+5/0CWjdN7HtwnZU5h/bwOQVyWYek04WXVk7tPQw2NHduW3XEqlDOq/YXH31b8wWJtmp2Lwck4nJ0cwBBCxpsw=="],
 
     "expo-image-picker": ["expo-image-picker@55.0.4", "", { "dependencies": { "expo-image-loader": "~55.0.0" }, "peerDependencies": { "expo": "*" } }, "sha512-xE9OwlBBMft2WwqQdhxaADbtw+wDzTk5gGgKdfmua9bfvXG6iLlGzLXIjnVle8UTP1CiOqspb4LhG/wr4hgjQw=="],
 
@@ -1114,6 +1159,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": "bin/jsesc" }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -1685,6 +1732,8 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1881,6 +1930,8 @@
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
     "@expo/cli/glob/minimatch": ["minimatch@10.1.2", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.1" } }, "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw=="],
 
     "@expo/cli/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -1932,6 +1983,8 @@
     "ora/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/package.json
+++ b/package.json
@@ -11,14 +11,17 @@
     "lint": "expo lint"
   },
   "dependencies": {
+    "@ai-sdk/amazon-bedrock": "^4.0.50",
     "@expo/vector-icons": "^15.0.3",
-    "@shopify/react-native-skia": "^2.4.18",
+    "@shopify/react-native-skia": "2.4.14",
+    "ai": "^6.0.74",
     "expo": "55.0.0-preview.9",
     "expo-constants": "~55.0.3",
     "expo-dev-client": "~55.0.4",
     "expo-font": "~55.0.3",
     "expo-haptics": "~55.0.4",
     "expo-image": "~55.0.3",
+    "expo-image-manipulator": "~55.0.4",
     "expo-image-picker": "~55.0.4",
     "expo-linking": "~55.0.3",
     "expo-router": "55.0.0-preview.6",

--- a/src/app/api/analyze+api.ts
+++ b/src/app/api/analyze+api.ts
@@ -1,0 +1,110 @@
+import { bedrock } from "@ai-sdk/amazon-bedrock";
+import { generateText } from "ai";
+
+interface AnalyzeRequest {
+  image: string; // base64-encoded image
+  mimeType: string; // e.g. "image/jpeg"
+}
+
+interface PanelResult {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: 0 | 90;
+  label: string;
+}
+
+interface AnalyzeResponse {
+  panels: PanelResult[];
+}
+
+const SYSTEM_PROMPT = `You are a solar panel array analyzer. You receive photos of solar panel installations and identify each individual panel.
+
+Return a JSON object with this exact structure:
+{
+  "panels": [
+    {
+      "x": <number>,
+      "y": <number>,
+      "width": <number>,
+      "height": <number>,
+      "rotation": <0 or 90>,
+      "label": "<string>"
+    }
+  ]
+}
+
+Rules:
+- x, y: position of the panel's top-left corner in pixel coordinates relative to the image
+- width, height: panel dimensions in pixels
+- rotation: 0 for portrait (taller than wide), 90 for landscape (wider than tall)
+- label: any text, serial number, or identifier visible on or near the panel. Use "" if none visible.
+- Return ONLY valid JSON, no markdown fences, no explanation.`;
+
+export async function POST(request: Request) {
+  try {
+    const { image, mimeType } = (await request.json()) as AnalyzeRequest;
+
+    if (!image || !mimeType) {
+      return Response.json(
+        { error: "Missing required fields: image, mimeType" },
+        { status: 400 },
+      );
+    }
+
+    const { text } = await generateText({
+      model: bedrock("us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Analyze this solar panel array photo. Identify each solar panel visible in the image.",
+            },
+            {
+              type: "image",
+              image,
+              mediaType: mimeType,
+            },
+          ],
+        },
+      ],
+      system: SYSTEM_PROMPT,
+      maxOutputTokens: 4096,
+      temperature: 0.2,
+    });
+
+    // Log raw response for debugging
+    console.log("Bedrock raw response:", text);
+
+    // Extract JSON from the response — the model may wrap it in markdown
+    // fences or include explanatory text before/after the JSON
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      console.error("No JSON found in model response:", text);
+      return Response.json(
+        { error: "Model did not return valid JSON" },
+        { status: 502 },
+      );
+    }
+
+    const result: AnalyzeResponse = JSON.parse(jsonMatch[0]);
+
+    if (!result.panels || !Array.isArray(result.panels)) {
+      return Response.json(
+        { error: "Invalid response format from model" },
+        { status: 502 },
+      );
+    }
+
+    return Response.json(result);
+  } catch (error) {
+    console.error("Analyze API error:", error);
+    return Response.json(
+      { error: "Failed to analyze image" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/custom.tsx
+++ b/src/app/custom.tsx
@@ -5,17 +5,18 @@ import { useSharedValue, withTiming } from "react-native-reanimated";
 import { SolarPanelCanvas } from "@/components/SolarPanelCanvas";
 import { usePanelsManager } from "@/hooks/usePanelsManager";
 import { PANEL_WIDTH, PANEL_HEIGHT } from "@/utils/panelUtils";
+import { GRID_SIZE } from "@/utils/gridSnap";
+import { consumeAnalysisResult } from "@/utils/analysisStore";
 
-// 2 rows x 5 columns grid, all portrait orientation
+// Fallback: 2 rows x 5 columns mock grid
 const COLS = 5;
 const PANEL_GAP = 6;
-const COL_SPACING = PANEL_WIDTH + PANEL_GAP; // 66
-const ROW_SPACING = PANEL_HEIGHT + PANEL_GAP; // 126
+const COL_SPACING = PANEL_WIDTH + PANEL_GAP;
+const ROW_SPACING = PANEL_HEIGHT + PANEL_GAP;
 const GRID_TOTAL_WIDTH = (COLS - 1) * COL_SPACING + PANEL_WIDTH;
-const GRID_TOTAL_HEIGHT = ROW_SPACING + PANEL_HEIGHT; // 2 rows
+const GRID_TOTAL_HEIGHT = ROW_SPACING + PANEL_HEIGHT;
 
 function buildMockPanelGrid(canvasWidth: number, canvasHeight: number) {
-  // Center the grid in the canvas
   const offsetX = Math.round((canvasWidth - GRID_TOTAL_WIDTH) / 2);
   const offsetY = Math.round((canvasHeight - GRID_TOTAL_HEIGHT) / 2);
 
@@ -24,6 +25,73 @@ function buildMockPanelGrid(canvasWidth: number, canvasHeight: number) {
     y: offsetY + Math.floor(i / COLS) * ROW_SPACING,
     rotation: 0 as const,
   }));
+}
+
+/**
+ * Map analysis results (pixel coords from an image) to canvas positions.
+ * Scales panels so they use the standard PANEL_WIDTH/PANEL_HEIGHT,
+ * preserving relative layout, centered in the canvas.
+ */
+function mapAnalysisToCanvasPositions(
+  panels: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    rotation: 0 | 90;
+  }[],
+  imageWidth: number,
+  imageHeight: number,
+  canvasWidth: number,
+  canvasHeight: number,
+) {
+  if (panels.length === 0) return [];
+
+  // Find the bounding box of all panels in image space
+  const minX = Math.min(...panels.map((p) => p.x));
+  const minY = Math.min(...panels.map((p) => p.y));
+  const maxX = Math.max(
+    ...panels.map((p) => p.x + (p.rotation === 90 ? p.height : p.width)),
+  );
+  const maxY = Math.max(
+    ...panels.map((p) => p.y + (p.rotation === 90 ? p.width : p.height)),
+  );
+
+  const layoutWidth = maxX - minX;
+  const layoutHeight = maxY - minY;
+
+  // Scale factor: map image-space layout to canvas units
+  // Use the average panel size in image space to determine scale
+  const avgPanelWidth =
+    panels.reduce(
+      (sum, p) => sum + (p.rotation === 90 ? p.height : p.width),
+      0,
+    ) / panels.length;
+  const scale = PANEL_WIDTH / avgPanelWidth;
+
+  // Scale the total layout size
+  const scaledWidth = layoutWidth * scale;
+  const scaledHeight = layoutHeight * scale;
+
+  // Center in canvas
+  const offsetX = Math.round((canvasWidth - scaledWidth) / 2);
+  const offsetY = Math.round((canvasHeight - scaledHeight) / 2);
+
+  return panels.map((p) => {
+    // Scale position relative to the layout bounding box
+    const rawX = offsetX + (p.x - minX) * scale;
+    const rawY = offsetY + (p.y - minY) * scale;
+
+    // Snap to grid
+    const x = Math.round(rawX / GRID_SIZE) * GRID_SIZE;
+    const y = Math.round(rawY / GRID_SIZE) * GRID_SIZE;
+
+    return {
+      x,
+      y,
+      rotation: p.rotation,
+    };
+  });
 }
 
 export default function Custom() {
@@ -45,21 +113,37 @@ export default function Custom() {
     initializePanels,
   } = usePanelsManager();
 
-  const handleLayout = useCallback((event: LayoutChangeEvent) => {
-    const { width, height } = event.nativeEvent.layout;
-    canvasSize.current = { width, height };
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const { width, height } = event.nativeEvent.layout;
+      canvasSize.current = { width, height };
 
-    // Initialize panels centered in the canvas after layout is known
-    if (initialPanels && !hasInitialized.current && width > 0 && height > 0) {
-      hasInitialized.current = true;
-      initializePanels(buildMockPanelGrid(width, height));
-    }
-  }, [initialPanels, initializePanels]);
+      // Initialize panels centered in the canvas after layout is known
+      if (initialPanels && !hasInitialized.current && width > 0 && height > 0) {
+        hasInitialized.current = true;
+
+        // Try to use real analysis results, fall back to mock grid
+        const analysis = consumeAnalysisResult();
+        if (analysis && analysis.panels.length > 0) {
+          const positions = mapAnalysisToCanvasPositions(
+            analysis.panels,
+            analysis.imageWidth,
+            analysis.imageHeight,
+            width,
+            height,
+          );
+          initializePanels(positions);
+        } else {
+          initializePanels(buildMockPanelGrid(width, height));
+        }
+      }
+    },
+    [initialPanels, initializePanels],
+  );
 
   const handleAddPanel = useCallback(() => {
     const { width, height } = canvasSize.current;
     if (width > 0 && height > 0) {
-      // Pass viewport offset so new panels are added relative to current view
       addPanel(width, height, -viewportX.value, -viewportY.value);
     }
   }, [addPanel, viewportX, viewportY]);
@@ -81,14 +165,12 @@ export default function Custom() {
     const { width, height } = canvasSize.current;
 
     if (states.length > 0) {
-      // Center viewport on first panel
       const firstPanel = states[0];
       const panelCenterX = firstPanel.x + PANEL_WIDTH / 2;
       const panelCenterY = firstPanel.y + PANEL_HEIGHT / 2;
       viewportX.value = withTiming(width / 2 - panelCenterX, { duration: 300 });
       viewportY.value = withTiming(height / 2 - panelCenterY, { duration: 300 });
     } else {
-      // Reset to origin
       viewportX.value = withTiming(0, { duration: 300 });
       viewportY.value = withTiming(0, { duration: 300 });
     }
@@ -98,10 +180,7 @@ export default function Custom() {
     <>
       <Stack.Screen.BackButton displayMode="minimal" />
       <Stack.Toolbar placement="right">
-        <Stack.Toolbar.Button
-          icon="location"
-          onPress={handleSnapToOrigin}
-        />
+        <Stack.Toolbar.Button icon="location" onPress={handleSnapToOrigin} />
       </Stack.Toolbar>
       <View style={styles.container} onLayout={handleLayout}>
         <SolarPanelCanvas
@@ -114,20 +193,14 @@ export default function Custom() {
         />
       </View>
       <Stack.Toolbar placement="bottom">
-        <Stack.Toolbar.Button
-          icon="plus"
-          onPress={handleAddPanel}
-        />
+        <Stack.Toolbar.Button icon="plus" onPress={handleAddPanel} />
         {selectedId && (
           <>
             <Stack.Toolbar.Button
               icon="rotate.right"
               onPress={handleRotatePanel}
             />
-            <Stack.Toolbar.Button
-              icon="trash"
-              onPress={handleDeletePanel}
-            />
+            <Stack.Toolbar.Button icon="trash" onPress={handleDeletePanel} />
           </>
         )}
       </Stack.Toolbar>
@@ -138,6 +211,6 @@ export default function Custom() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#f9fafb", // gray-50
+    backgroundColor: "#f9fafb",
   },
 });

--- a/src/utils/analysisStore.ts
+++ b/src/utils/analysisStore.ts
@@ -1,0 +1,34 @@
+/**
+ * Simple module-level store for passing analysis results between screens.
+ * Avoids putting large JSON in URL search params.
+ */
+
+interface PanelResult {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: 0 | 90;
+  label: string;
+}
+
+interface AnalysisResult {
+  panels: PanelResult[];
+  imageWidth: number;
+  imageHeight: number;
+}
+
+let pendingResult: AnalysisResult | null = null;
+
+export function setAnalysisResult(result: AnalysisResult) {
+  pendingResult = result;
+}
+
+/**
+ * Consume the pending analysis result (returns it once, then clears).
+ */
+export function consumeAnalysisResult(): AnalysisResult | null {
+  const result = pendingResult;
+  pendingResult = null;
+  return result;
+}

--- a/src/utils/imageResize.ts
+++ b/src/utils/imageResize.ts
@@ -1,0 +1,54 @@
+import { manipulateAsync, SaveFormat } from "expo-image-manipulator";
+
+const MAX_LONG_EDGE = 1568; // Claude auto-downscales beyond this
+const JPEG_QUALITY = 0.8;
+
+interface ResizedImage {
+  base64: string;
+  mimeType: "image/jpeg";
+  width: number;
+  height: number;
+}
+
+/**
+ * Resize an image so its longest edge is at most MAX_LONG_EDGE pixels,
+ * compress to JPEG, and return as base64.
+ *
+ * This keeps uploads well under the 3.75MB Bedrock wire-size limit
+ * and avoids Claude's automatic downscaling latency.
+ */
+export async function resizeForAnalysis(uri: string): Promise<ResizedImage> {
+  // First, get the original dimensions by manipulating with no actions
+  const original = await manipulateAsync(uri, [], {
+    format: SaveFormat.JPEG,
+  });
+
+  const { width: origW, height: origH } = original;
+  const longEdge = Math.max(origW, origH);
+
+  // Only resize if the image exceeds the max
+  const actions =
+    longEdge > MAX_LONG_EDGE
+      ? [
+          {
+            resize:
+              origW >= origH
+                ? { width: MAX_LONG_EDGE }
+                : { height: MAX_LONG_EDGE },
+          } as const,
+        ]
+      : [];
+
+  const result = await manipulateAsync(uri, actions, {
+    format: SaveFormat.JPEG,
+    compress: JPEG_QUALITY,
+    base64: true,
+  });
+
+  return {
+    base64: result.base64!,
+    mimeType: "image/jpeg",
+    width: result.width,
+    height: result.height,
+  };
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,84 @@
+# Terraform — AWS Bedrock IAM
+
+Creates an IAM user with minimal permissions to call Bedrock (Claude) from EAS Hosting API routes.
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.0
+- AWS CLI configured with credentials that can create IAM resources
+- Claude model access enabled in the [AWS Bedrock console](https://console.aws.amazon.com/bedrock/home#/modelaccess) (one-time per account)
+
+## Setup
+
+### 1. Create the S3 state bucket (one-time)
+
+```bash
+aws s3api create-bucket \
+  --bucket react-native-array-layout-2 \
+  --region us-east-1
+```
+
+Enable versioning so you can recover previous state files:
+
+```bash
+aws s3api put-bucket-versioning \
+  --bucket react-native-array-layout-2 \
+  --versioning-configuration Status=Enabled
+```
+
+### 2. Configure the backend
+
+```bash
+cp backend.hcl.example backend.hcl
+```
+
+Edit `backend.hcl` and set the bucket name you created above.
+
+### 3. Initialize Terraform
+
+```bash
+terraform init -backend-config=backend.hcl
+```
+
+### 4. Review changes
+
+```bash
+terraform plan
+```
+
+### 5. Apply
+
+```bash
+terraform apply
+```
+
+## Post-apply: set EAS secrets
+
+Retrieve the credentials from Terraform output:
+
+```bash
+terraform output access_key_id
+terraform output -raw secret_access_key
+```
+
+Then store them as EAS secrets:
+
+```bash
+eas env:create --name AWS_ACCESS_KEY_ID     --value "..." --environment production --visibility sensitive
+eas env:create --name AWS_SECRET_ACCESS_KEY  --value "..." --environment production --visibility sensitive
+eas env:create --name AWS_REGION             --value "us-east-1" --environment production --visibility plaintext
+```
+
+For local development, pull env vars into a `.env` file:
+
+```bash
+eas env:pull --environment development
+```
+
+## Resources created
+
+| Resource | Purpose |
+|----------|---------|
+| `aws_iam_user.bedrock_api` | IAM user `eas-bedrock-api` |
+| `aws_iam_access_key.bedrock_api` | Access key for the IAM user |
+| `aws_iam_user_policy.bedrock_invoke` | Inline policy allowing `bedrock:InvokeModel` on Claude models |

--- a/terraform/backend.hcl.example
+++ b/terraform/backend.hcl.example
@@ -1,0 +1,1 @@
+bucket = "your-terraform-state-bucket-name"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_version = ">= 1.0"
+
+  backend "s3" {
+    key    = "react-native-array-layout/terraform.tfstate"
+    region = "us-east-1"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_caller_identity" "current" {}
+
+# IAM user for EAS Hosting API routes to call Bedrock
+resource "aws_iam_user" "bedrock_api" {
+  name = "eas-bedrock-api"
+  tags = {
+    Project = "react-native-array-layout"
+    Purpose = "EAS Hosting Bedrock access"
+  }
+}
+
+resource "aws_iam_access_key" "bedrock_api" {
+  user = aws_iam_user.bedrock_api.name
+}
+
+# Minimal policy: only InvokeModel on Claude models
+resource "aws_iam_user_policy" "bedrock_invoke" {
+  name = "bedrock-invoke-claude"
+  user = aws_iam_user.bedrock_api.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ]
+      Resource = [
+        "arn:aws:bedrock:*::foundation-model/anthropic.claude-*",
+        "arn:aws:bedrock:*::inference-profile/us.anthropic.claude-*",
+        "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-*"
+      ]
+    }]
+  })
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,10 @@
+output "access_key_id" {
+  description = "AWS access key ID for EAS Hosting secrets"
+  value       = aws_iam_access_key.bedrock_api.id
+}
+
+output "secret_access_key" {
+  description = "AWS secret access key for EAS Hosting secrets"
+  value       = aws_iam_access_key.bedrock_api.secret
+  sensitive   = true
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  description = "AWS region for Bedrock model access"
+  type        = string
+  default     = "us-east-1"
+}


### PR DESCRIPTION
## Summary

- Add Expo API route that sends uploaded photos to Claude Sonnet 4.5 on AWS Bedrock for vision analysis
- Client-side image resize (max 1568px, JPEG quality 80) before upload via `expo-image-manipulator`
- Module-level store (`analysisStore.ts`) to pass analysis results between upload and canvas screens
- Upload screen calls the API route and shows processing overlay during analysis
- Canvas screen maps Bedrock analysis results to panel positions with grid snapping
- Terraform config (`terraform/`) for IAM user with minimal `bedrock:InvokeModel` permissions and S3 backend for state
- Updated CLAUDE.md and README.md with new architecture documentation

## Test plan

- [ ] Set AWS credentials in `.env` (see `.env.example`)
- [ ] Run `npx expo serve` to start API routes locally
- [ ] Upload a photo of a solar panel array → verify processing overlay appears
- [ ] Verify Bedrock returns panel JSON (check terminal logs)
- [ ] Verify canvas screen renders panels from analysis results
- [ ] Run `terraform plan` in `terraform/` directory to verify IAM config
- [ ] Run `bun run lint && bun ./node_modules/.bin/tsc --noEmit` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)