### PR TITLE
Unified Panel Details Form Sheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ src/
 │   ├── upload.tsx          # Step 2: Upload & AI analysis
 │   ├── custom.tsx          # Step 3: Canvas editor with toolbar
 │   ├── production.tsx      # Production monitor (real-time wattage)
-│   ├── link-inverter.tsx   # Modal: Link panel to inverter
+│   ├── panel-details.tsx   # Form sheet: View/link panel to inverter
 │   └── api/
 │       └── analyze+api.ts  # Bedrock API route (Claude vision)
 ├── components/
@@ -391,13 +391,24 @@ The production monitor (`src/app/production.tsx`) displays real-time array outpu
 |---------|------------------|------------------|
 | Panel dragging | Yes | No |
 | Panel selection | Yes | No |
+| Panel tap action | Select + toolbar | Opens panel-details sheet |
 | Wattage display | No | Yes |
 | Color coding | Link status only | Output level |
 | Viewport panning | Yes | Yes |
 | Zoom controls | Yes | Yes |
 
+## Panel Details Form Sheet
+
+The `panel-details.tsx` screen is a unified form sheet for viewing and editing panel-inverter links:
+
+- **View mode** (`mode=view`): Opens at 30% height, shows serial number and efficiency (read-only)
+- **Edit mode** (default): Opens at 60% height, allows linking/unlinking inverters
+- Uses native `@expo/ui/swift-ui` components (Form, Section, LabeledContent, List.ForEach)
+- Accessed from:
+  - **Custom screen**: Tap link button in toolbar to edit panel-inverter link
+  - **Production screen**: Tap any linked panel to view its inverter details
+
 ## Planned Integrations
 
 - **EAS Hosting** - Server-side API route deployment
 - **Compass indicator** - Array orientation display
-- **Panel detail sheet** - Bottom sheet with serial number and metadata

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ After completing the wizard, view real-time power production:
   - Yellow: Medium output (40-80%)
   - Red: Low output (<40%)
   - Gray: Unlinked panels (0W)
+- **Tap any panel** to view its linked inverter details (serial number, efficiency)
 - Production updates every second with realistic fluctuation
 - Formula: `efficiency × maxWattage × (0.95 + random × 0.1)`
 
@@ -167,7 +168,7 @@ src/
 │   ├── upload.tsx         # Step 2: Upload & AI analysis
 │   ├── custom.tsx         # Step 3: Canvas editor with toolbar
 │   ├── production.tsx     # Production monitor (real-time wattage)
-│   ├── link-inverter.tsx  # Modal: Link panel to inverter
+│   ├── panel-details.tsx  # Form sheet: View/link panel to inverter
 │   └── api/
 │       └── analyze+api.ts # Bedrock API route (Claude vision analysis)
 ├── components/
@@ -228,9 +229,13 @@ terraform/
   - 3-step progress indicator (Configure → Photo → Layout)
   - Navigation buttons (Continue, Skip, Finish)
   - wizardCompleted flag for returning users
+- [x] Create panel details form sheet
+  - Unified form sheet for viewing and linking inverters
+  - Dynamic sheet height: 30% for view mode, 60% for edit mode
+  - Uses native @expo/ui/swift-ui components
+  - Tap panels in Production screen to view inverter details
 - [ ] Deploy API routes to EAS Hosting
 - [ ] Implement compass orientation indicator
-- [ ] Create panel detail bottom sheet
 
 ---
 

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -38,12 +38,11 @@ export default function RootLayout() {
           }}
         />
         <Stack.Screen
-          name="link-inverter"
+          name="panel-details"
           options={{
             presentation: "formSheet",
             sheetGrabberVisible: true,
-            sheetAllowedDetents: [0.6, 1.0],
-            title: "Link Inverter",
+            title: "Panel Details",
             contentStyle: { backgroundColor: "transparent" },
           }}
         />

--- a/src/app/link-inverter.tsx
+++ b/src/app/link-inverter.tsx
@@ -1,21 +1,36 @@
 import {useCallback, useState, useEffect} from 'react';
-import {ScrollView, View, Text, Pressable, StyleSheet, useColorScheme} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import {Link, useLocalSearchParams, useRouter} from 'expo-router';
 import * as Haptics from 'expo-haptics';
 import {useConfigStore} from '@/hooks/useConfigStore';
 import {usePanelsContext} from '@/contexts/PanelsContext';
 import {getPanelStore, subscribe} from '@/utils/panelStore';
-import {Ionicons} from '@expo/vector-icons';
-import {useColors} from '@/utils/theme';
+import {
+  Button,
+  Form,
+  Host,
+  HStack,
+  Image,
+  LabeledContent,
+  List,
+  Section,
+  Spacer,
+  Text,
+  VStack,
+} from '@expo/ui/swift-ui';
+import {
+  bold,
+  buttonStyle,
+  font,
+  foregroundStyle,
+  opacity,
+} from '@expo/ui/swift-ui/modifiers';
 
 export default function LinkInverterScreen() {
   const { panelId } = useLocalSearchParams<{ panelId: string }>();
   const { config } = useConfigStore();
   const { linkInverter } = usePanelsContext();
   const router = useRouter();
-  const colors = useColors();
-  const colorScheme = useColorScheme();
-  const isDark = colorScheme === "dark";
 
   // Read from store instead of SharedValues
   const [storeData, setStoreData] = useState(() => getPanelStore());
@@ -64,93 +79,79 @@ export default function LinkInverterScreen() {
   }, [panelId, linkInverter, router]);
 
   return (
-    <ScrollView
-      contentInsetAdjustmentBehavior="automatic"
-      style={[styles.container, { backgroundColor: colors.background.secondary }]}
-      contentContainerStyle={styles.contentContainer}
-    >
-      {currentInverter ? (
-        // Show currently linked inverter
-        <View style={styles.section}>
-          <Text style={[styles.sectionHeader, { color: colors.text.secondary }]}>LINKED INVERTER</Text>
-          <View style={[styles.card, { backgroundColor: colors.background.primary, boxShadow: isDark ? '0 1px 3px rgba(255, 255, 255, 0.2)' : '0 1px 3px rgba(0, 0, 0, 0.08)' }]}>
-            <View style={styles.infoRow}>
-              <Text style={[styles.label, { color: colors.text.primary }]}>Serial Number</Text>
-              <Text style={[styles.value, { color: colors.text.secondary }]}>{currentInverter.serialNumber}</Text>
-            </View>
-            <View style={[styles.separator, { backgroundColor: colors.border.medium }]} />
-            <View style={styles.infoRow}>
-              <Text style={[styles.label, { color: colors.text.primary }]}>Efficiency</Text>
-              <Text style={[styles.value, { color: colors.text.secondary }]}>{Math.round(currentInverter.efficiency)}%</Text>
-            </View>
-            <View style={[styles.separator, { backgroundColor: colors.border.medium }]} />
-            <Pressable
-              style={({pressed}) => [
-                styles.unlinkButton,
-                pressed && { backgroundColor: colors.background.tertiary }
-              ]}
-              onPress={handleUnlink}
+    <View style={styles.container}>
+      <Host style={styles.host}>
+        <Form>
+          {currentInverter ? (
+            // Show currently linked inverter
+            <Section
+              header={<Text>Linked Inverter</Text>}
             >
-              <Ionicons name="unlink" size={20} color={colors.system.red} />
-              <Text style={[styles.unlinkButtonText, { color: colors.system.red }]}>Unlink Inverter</Text>
-            </Pressable>
-          </View>
-        </View>
-      ) : availableInverters.length > 0 ? (
-        // Show list of available inverters
-        <View style={styles.section}>
-          <Text style={[styles.sectionHeader, { color: colors.text.secondary }]}>AVAILABLE INVERTERS</Text>
-          <View style={[styles.card, { backgroundColor: colors.background.primary, boxShadow: isDark ? '0 1px 3px rgba(255, 255, 255, 0.2)' : '0 1px 3px rgba(0, 0, 0, 0.08)' }]}>
-            {availableInverters.map((inv, index) => (
-              <View key={inv.id}>
-                {index > 0 && <View style={[styles.separator, { backgroundColor: colors.border.medium }]} />}
-                <Pressable
-                  style={({pressed}) => [
-                    styles.inverterItem,
-                    pressed && { backgroundColor: colors.background.tertiary }
-                  ]}
-                  onPress={() => handleLink(inv.id)}
-                >
-                  <View style={styles.inverterInfo}>
-                    <Text style={[styles.serialNumber, { color: colors.text.primary }]}>{inv.serialNumber}</Text>
-                    <Text style={[styles.efficiency, { color: colors.text.secondary }]}>{Math.round(inv.efficiency)}% efficiency</Text>
-                  </View>
-                  <Ionicons name="chevron-forward" size={20} color={colors.text.tertiary} />
-                </Pressable>
-              </View>
-            ))}
-          </View>
-          <Text style={[styles.sectionFooter, { color: colors.text.secondary }]}>Select a micro-inverter to link to this panel.</Text>
-        </View>
-      ) : (
-        // Empty state - no available inverters
-        <View style={styles.section}>
-          <View style={styles.emptyState}>
-            <Ionicons name="warning" size={56} color={colors.text.secondary} />
-            <Text style={[styles.emptyTitle, { color: colors.text.primary }]}>No Available Inverters</Text>
-            <Text style={[styles.emptyDescription, { color: colors.text.secondary }]}>
-              All inverters are assigned. Unlink a panel first or add a new inverter.
-            </Text>
-          </View>
-          <View style={[styles.buttonContainer, { backgroundColor: colors.primary }]}>
-            <Link href="/config" asChild>
-              <Pressable
-                style={({pressed}) => [
-                  styles.addButton,
-                  { backgroundColor: colors.primary, boxShadow: isDark ? '0 4px 12px rgba(96, 165, 250, 0.6)' : '0 4px 12px rgba(59, 130, 246, 0.6)' },
-                  pressed && styles.addButtonPressed
-                ]}
-              >
-                <View style={styles.buttonContent}>
-                  <Ionicons name="add-circle" size={22} color={colors.text.inverse} />
-                  <Text style={[styles.addButtonText, { color: colors.text.inverse }]}>Add Inverter</Text>
-                </View>
-              </Pressable>
-            </Link>
-          </View>
-        </View>
-      )}
-    </ScrollView>
+              <LabeledContent label="Serial Number">
+                <Text>{currentInverter.serialNumber}</Text>
+              </LabeledContent>
+              <LabeledContent label="Efficiency">
+                <Text>{Math.round(currentInverter.efficiency)}%</Text>
+              </LabeledContent>
+              <Button onPress={handleUnlink} modifiers={[buttonStyle('plain')]}>
+                <HStack spacing={8}>
+                  <Image systemName="link.badge.plus" size={20} color="#FF3B30" />
+                  <Text modifiers={[foregroundStyle({type: 'color', color: '#FF3B30'}), bold()]}>
+                    Unlink Inverter
+                  </Text>
+                </HStack>
+              </Button>
+            </Section>
+          ) : availableInverters.length > 0 ? (
+            // Show list of available inverters
+            <Section
+              header={<Text>Available Inverters</Text>}
+              footer={<Text>Select a micro-inverter to link to this panel.</Text>}
+            >
+              <List.ForEach>
+                {availableInverters.map((inv) => (
+                  <Button key={inv.id} onPress={() => handleLink(inv.id)} modifiers={[buttonStyle('plain')]}>
+                    <HStack>
+                      <VStack alignment="leading" spacing={2}>
+                        <Text modifiers={[foregroundStyle({type: 'hierarchical', style: 'primary'})]}>
+                          {inv.serialNumber}
+                        </Text>
+                        <Text modifiers={[opacity(0.6), font({size: 14})]}>
+                          {Math.round(inv.efficiency)}% efficiency
+                        </Text>
+                      </VStack>
+                      <Spacer />
+                      <Image systemName="chevron.right" size={14} color="#C7C7CC" />
+                    </HStack>
+                  </Button>
+                ))}
+              </List.ForEach>
+            </Section>
+          ) : (
+            // Empty state - no available inverters
+            <Section>
+              <VStack spacing={16}>
+                <Image systemName="exclamationmark.triangle" size={56} color="#8E8E93" />
+                <Text modifiers={[bold(), font({size: 20})]}>No Available Inverters</Text>
+                <Text modifiers={[opacity(0.6), font({size: 15})]}>
+                  All inverters are assigned. Unlink a panel first or add a new inverter.
+                </Text>
+                <Link href="/config" asChild>
+                  <Button>
+                    <HStack>
+                      <Image systemName="plus.circle" size={22} color="#007AFF" />
+                      <Text modifiers={[foregroundStyle({type: 'color', color: '#007AFF'}), bold()]}>
+                        Add Inverter
+                      </Text>
+                    </HStack>
+                  </Button>
+                </Link>
+              </VStack>
+            </Section>
+          )}
+        </Form>
+      </Host>
+    </View>
   );
 }
 
@@ -158,123 +159,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  contentContainer: {
-    padding: 16,
-    paddingTop: 24,
-  },
-  section: {
-    marginBottom: 32,
-  },
-  sectionHeader: {
-    fontSize: 13,
-    fontWeight: '600',
-    marginBottom: 8,
-    marginLeft: 16,
-    letterSpacing: -0.08,
-  },
-  sectionFooter: {
-    fontSize: 13,
-    marginTop: 8,
-    marginLeft: 16,
-    lineHeight: 18,
-  },
-  card: {
-    borderRadius: 10,
-    borderCurve: 'continuous',
-    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08)',
-    overflow: 'hidden',
-  },
-  infoRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: 16,
-  },
-  label: {
-    fontSize: 17,
-  },
-  value: {
-    fontSize: 17,
-    fontWeight: '600',
-  },
-  separator: {
-    height: StyleSheet.hairlineWidth,
-    marginLeft: 16,
-  },
-  unlinkButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 16,
-    gap: 8,
-  },
-  unlinkButtonText: {
-    fontSize: 17,
-    fontWeight: '600',
-  },
-  inverterItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    padding: 16,
-  },
-  inverterInfo: {
+  host: {
     flex: 1,
-    gap: 2,
-  },
-  serialNumber: {
-    fontSize: 17,
-    fontWeight: '400',
-  },
-  efficiency: {
-    fontSize: 15,
-  },
-  emptyState: {
-    alignItems: 'center',
-    paddingVertical: 40,
-    paddingHorizontal: 32,
-    gap: 16,
-    borderRadius: 16,
-    borderCurve: 'continuous',
-    marginHorizontal: 16,
-    marginBottom: 16,
-  },
-  emptyTitle: {
-    fontSize: 20,
-    fontWeight: '700',
-    textAlign: 'center',
-  },
-  emptyDescription: {
-    fontSize: 15,
-    textAlign: 'center',
-    lineHeight: 20,
-    fontWeight: '500',
-  },
-  buttonContainer: {
-    paddingHorizontal: 32,
-    paddingVertical: 16,
-    borderRadius: 16,
-    marginHorizontal: 16,
-  },
-  addButton: {
-    paddingVertical: 16,
-    paddingHorizontal: 24,
-    borderRadius: 12,
-    borderCurve: 'continuous',
-    boxShadow: '0 4px 12px rgba(59, 130, 246, 0.6)',
-    overflow: 'hidden',
-  },
-  addButtonPressed: {
-    opacity: 0.8,
-  },
-  buttonContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 10,
-  },
-  addButtonText: {
-    fontSize: 18,
-    fontWeight: '700',
   },
 });

--- a/src/components/ProductionCanvas.tsx
+++ b/src/components/ProductionCanvas.tsx
@@ -107,8 +107,8 @@ export function ProductionCanvas({
       isPanningViewport.value = false;
     });
 
-  // Combine tap and pan gestures - tap takes priority
-  const combinedGestures = Gesture.Race(tapGesture, panGesture);
+  // Combine gestures - pan takes priority but tap works when no drag occurs
+  const combinedGestures = Gesture.Exclusive(panGesture, tapGesture);
 
   return (
     <GestureDetector gesture={combinedGestures}>

--- a/src/components/ProductionCanvas.tsx
+++ b/src/components/ProductionCanvas.tsx
@@ -6,9 +6,12 @@ import {
   useDerivedValue,
   type SharedValue,
 } from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
 import { ProductionPanel } from "./ProductionPanel";
 import type { PanelData } from "@/hooks/usePanelsManager";
 import type { PanelColors } from "./SolarPanel";
+import type { PanelState } from "@/utils/panelUtils";
+import { hitTestPanels } from "@/utils/panelUtils";
 import { useColors } from "@/utils/theme";
 
 interface ProductionCanvasProps {
@@ -19,6 +22,7 @@ interface ProductionCanvasProps {
   scale: SharedValue<number>;
   canvasWidth: SharedValue<number>;
   canvasHeight: SharedValue<number>;
+  onPanelTap?: (panelId: string) => void;
 }
 
 export function ProductionCanvas({
@@ -29,6 +33,7 @@ export function ProductionCanvas({
   scale,
   canvasWidth,
   canvasHeight,
+  onPanelTap,
 }: ProductionCanvasProps) {
   const colors = useColors();
   const panelColors: PanelColors = {
@@ -55,6 +60,34 @@ export function ProductionCanvas({
     ];
   });
 
+  // Tap gesture for panel selection
+  const tapGesture = Gesture.Tap()
+    .onEnd((e) => {
+      "worklet";
+      // Convert screen coordinates to world coordinates
+      const cx = canvasWidth.value / 2;
+      const cy = canvasHeight.value / 2;
+      const worldX = (e.x - cx) / scale.value + cx - viewportX.value;
+      const worldY = (e.y - cy) / scale.value + cy - viewportY.value;
+
+      // Build states for hit testing
+      const states: PanelState[] = [];
+      for (const p of panels) {
+        states.push({
+          id: p.id,
+          x: p.x.value,
+          y: p.y.value,
+          rotation: p.rotation.value,
+          inverterId: p.inverterId.value,
+        });
+      }
+
+      const hitId = hitTestPanels(worldX, worldY, states);
+      if (hitId && onPanelTap) {
+        scheduleOnRN(onPanelTap, hitId);
+      }
+    });
+
   // Pan gesture for viewport panning only
   const panGesture = Gesture.Pan()
     .onStart(() => {
@@ -74,8 +107,11 @@ export function ProductionCanvas({
       isPanningViewport.value = false;
     });
 
+  // Combine tap and pan gestures - tap takes priority
+  const combinedGestures = Gesture.Race(tapGesture, panGesture);
+
   return (
-    <GestureDetector gesture={panGesture}>
+    <GestureDetector gesture={combinedGestures}>
       <Canvas style={styles.canvas}>
         <Group transform={canvasTransform}>
           {panels.map((panel) => (


### PR DESCRIPTION
## Summary

- **Rename** `link-inverter.tsx` → `panel-details.tsx` to reflect dual purpose
- **Refactor** to use native `@expo/ui/swift-ui` components (Form, Section, LabeledContent, List.ForEach)
- **Add tap gesture** to ProductionCanvas to open panel details when tapping linked panels
- **Dynamic sheet sizing**: 30% for view mode, 60% for edit mode
- **Replace deprecated** `runOnUI` with `scheduleOnUI` from `react-native-worklets`
- **Fix** `scheduleOnRN` usage pattern (pass function reference + args, not arrow function)

## Changes

| Screen | Before | After |
|--------|--------|-------|
| Custom → Link | Custom RN styling, navigates to link-inverter | Native iOS styling, navigates to panel-details |
| Production → Tap Panel | Inline BottomSheet | Navigates to panel-details (view mode) |
| Sheet height | Fixed 60% | Dynamic: 30% (view) / 60% (edit) |

## Test plan

- [ ] From Custom screen: tap panel → tap link button → verify form sheet opens at 60%, can link/unlink
- [ ] From Production screen: tap linked panel → verify form sheet opens at 30% with serial number + efficiency
- [ ] Verify unlinked panels in Production don't open sheet
- [ ] Verify native iOS styling matches config screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)