### PR TITLE
Add compass orientation indicator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,7 +450,7 @@ The `Compass.tsx` component displays array orientation on Custom and Production 
 - 80×80px Skia canvas
 - 4 curved arc segments at diagonal positions (NE, SE, SW, NW)
 - N, E, S, W labels positioned between arcs on the ring
-- Arrow with diamond cutout pointing to current direction
+- Arrow with triangle cutout pointing to current direction
 
 **Interaction (Custom screen):**
 - Drag arrow to rotate (follows touch position)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,12 @@ src/
 │   ├── production.tsx      # Production monitor (real-time wattage, menu)
 │   ├── panel-details.tsx   # Form sheet: View/link panel to inverter
 │   ├── inverter-details.tsx # Form sheet: Add/edit micro-inverters
+│   ├── compass-help.tsx    # Form sheet: Compass usage instructions
 │   └── api/
 │       └── analyze+api.ts  # Bedrock API route (Claude vision)
 ├── components/
 │   ├── Button.tsx          # Reusable button component
+│   ├── Compass.tsx         # Interactive compass for array orientation
 │   ├── ImagePreview.tsx    # Image preview
 │   ├── PermissionModal.tsx # Camera permission UI
 │   ├── ProcessingOverlay.tsx # Fibonacci shader + shimmer text
@@ -350,6 +352,7 @@ interface SystemConfig {
   defaultMaxWattage: number;
   inverters: InverterConfig[];
   wizardCompleted: boolean;  // Tracks if user has completed wizard
+  compassDirection: number;  // Array orientation in degrees (0-360, 0 = North)
 }
 ```
 
@@ -362,6 +365,7 @@ interface SystemConfig {
 - `removeInverter(id)` - Delete inverter
 - `getWizardCompleted()` - Check if wizard was completed
 - `setWizardCompleted(completed)` - Mark wizard as complete
+- `updateCompassDirection(degrees)` - Update array orientation (0-360°)
 - `resetAllData()` - Reset all config to defaults (used by Delete Configuration)
 - `subscribe(listener)` - Subscribe to config changes
 
@@ -436,7 +440,32 @@ The `inverter-details.tsx` screen is a form sheet for adding and editing micro-i
 - Form fields: Serial number (numeric), efficiency slider (0-100%)
 - Accessed from **Config screen**: Tap "+" to add, tap existing inverter to edit
 
+## Compass Component
+
+The `Compass.tsx` component displays array orientation on Custom and Production screens:
+
+**Location:** Top-right corner of canvas (absolute positioned)
+
+**Visual Design:**
+- 80×80px Skia canvas
+- 4 curved arc segments at diagonal positions (NE, SE, SW, NW)
+- N, E, S, W labels positioned between arcs on the ring
+- Arrow with diamond cutout pointing to current direction
+
+**Interaction (Custom screen):**
+- Drag arrow to rotate (follows touch position)
+- Snaps to 8 directions on release (N, NE, E, SE, S, SW, W, NW)
+- Haptic feedback on snap
+- Tap opens compass-help form sheet
+
+**Read-only mode (Production screen):**
+- Displays saved direction statically
+- No gesture interaction
+
+**State:**
+- Direction stored in `configStore.compassDirection` (0-360°)
+- Persisted via `expo-sqlite/kv-store`
+
 ## Planned Integrations
 
 - **EAS Hosting** - Server-side API route deployment
-- **Compass indicator** - Array orientation display

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Create or confirm your panel layout:
 - If dropped in invalid position, panel reverts to original location
 - Rotate panels, use grid snapping
 - Zoom in/out (3 levels) to view large arrays on smaller screens
+- **Compass indicator** in top-right corner to set array orientation (tap for help)
 
 ### Production Monitor
 
@@ -66,6 +67,7 @@ After completing the wizard, view real-time power production:
 - **Auto-centered viewport** - On load, centers on all panels for optimal visibility
 - **Total array output** displayed prominently at top
 - Same canvas view as editor, but read-only (no editing)
+- **Compass indicator** shows saved array orientation (read-only)
 - Each panel displays current wattage with color coding:
   - Green: High output (>80% efficiency)
   - Yellow: Medium output (40-80%)
@@ -178,9 +180,11 @@ src/
 │   ├── custom.tsx         # Step 3: Canvas editor with toolbar
 │   ├── production.tsx     # Production monitor (real-time wattage)
 │   ├── panel-details.tsx  # Form sheet: View/link panel to inverter
+│   ├── compass-help.tsx   # Form sheet: Compass usage instructions
 │   └── api/
 │       └── analyze+api.ts # Bedrock API route (Claude vision analysis)
 ├── components/
+│   ├── Compass.tsx        # Interactive compass for array orientation
 │   ├── ImagePreview.tsx   # Image preview component
 │   ├── PermissionModal.tsx # Camera permission modal
 │   ├── ProcessingOverlay.tsx # Fibonacci shader + shimmer text overlay
@@ -242,8 +246,12 @@ terraform/
   - Dynamic sheet height: 30% for view mode, 60% for edit mode
   - Uses native @expo/ui/swift-ui components
   - Tap panels in Production screen to view inverter details
+- [x] Implement compass orientation indicator
+  - Interactive compass in top-right of Custom screen
+  - Drag arrow to set array orientation (snaps to 8 directions)
+  - Tap for help sheet with usage instructions
+  - Read-only compass on Production screen
 - [ ] Deploy API routes to EAS Hosting
-- [ ] Implement compass orientation indicator
 
 ---
 

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -56,6 +56,16 @@ export default function RootLayout() {
           }}
         />
         <Stack.Screen
+          name="compass-help"
+          options={{
+            presentation: "formSheet",
+            sheetGrabberVisible: true,
+            title: "",
+            headerShown: false,
+            contentStyle: { backgroundColor: "transparent" },
+          }}
+        />
+        <Stack.Screen
           name="production"
           options={{
             title: "",

--- a/src/app/compass-help.tsx
+++ b/src/app/compass-help.tsx
@@ -1,0 +1,40 @@
+import {StyleSheet, View} from "react-native";
+import {Stack} from "expo-router";
+import {Host, Image, Text, VStack,} from "@expo/ui/swift-ui";
+import {bold, font, opacity, padding} from "@expo/ui/swift-ui/modifiers";
+
+export default function CompassHelpScreen() {
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          sheetAllowedDetents: [0.3],
+        }}
+      />
+      <View style={styles.container}>
+        <Host style={styles.host}>
+          <VStack spacing={12}>
+            <Image systemName="location.north.fill" size={40} color="#007AFF"/>
+            <Text modifiers={[bold(), font({size: 18})]}>
+              Array Orientation
+            </Text>
+            <Text modifiers={[opacity(0.7), font({size: 15}), padding({horizontal: 16})]}>
+              Drag the arrow to indicate which direction the top of your
+              panel array faces. This helps track your array&apos;s orientation
+              for optimal sun exposure.
+            </Text>
+          </VStack>
+        </Host>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  host: {
+    flex: 1,
+  },
+});

--- a/src/app/config.tsx
+++ b/src/app/config.tsx
@@ -1,4 +1,4 @@
-import {Keyboard, StyleSheet, TouchableWithoutFeedback, View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import {
   Button,
   Form,
@@ -19,6 +19,7 @@ import {
   foregroundStyle,
   opacity,
   scrollDismissesKeyboard,
+  submitLabel,
 } from '@expo/ui/swift-ui/modifiers';
 import {useConfigStore} from '@/hooks/useConfigStore';
 import type {InverterConfig} from '@/utils/configStore';
@@ -64,10 +65,9 @@ export default function ConfigScreen() {
     <>
       <Stack.Screen.BackButton displayMode="minimal"/>
       {isWizardMode && <WizardProgress currentStep={1}/>}
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <View style={styles.container}>
-          <Host style={styles.form}>
-            <Form modifiers={[scrollDismissesKeyboard('interactively')]}>
+      <View style={styles.container}>
+        <Host style={styles.form}>
+            <Form modifiers={[scrollDismissesKeyboard('immediately')]}>
               {/* Panel Settings Section */}
               <Section
                 header={<Text>Panel Settings</Text>}
@@ -78,13 +78,14 @@ export default function ConfigScreen() {
                   </Text>
                 }
               >
-                <LabeledContent label="Default Wattage">
+                <LabeledContent label="Default Production">
                   <HStack>
                     <TextField
-                      keyboardType="numeric"
+                      keyboardType="numbers-and-punctuation"
                       defaultValue={config.defaultMaxWattage.toString()}
                       onChangeText={handleWattageChange}
                       placeholder="430"
+                      modifiers={[submitLabel('done')]}
                     />
                     <Spacer/>
                     <Text testID='text-input-unit'>W</Text>
@@ -129,7 +130,6 @@ export default function ConfigScreen() {
             </Form>
           </Host>
         </View>
-      </TouchableWithoutFeedback>
       <Stack.Toolbar placement="bottom">
         {isWizardMode && (
           <Stack.Toolbar.Button onPress={handleContinue}>

--- a/src/app/custom.tsx
+++ b/src/app/custom.tsx
@@ -115,6 +115,7 @@ export default function Custom() {
   const canvasHeight = useSharedValue(0);
   const hasInitialized = useRef(false);
   const [zoomIndex, setZoomIndex] = useState(DEFAULT_ZOOM_INDEX);
+  const [compassVisible, setCompassVisible] = useState(false);
   const { config, setWizardCompleted, updateCompassDirection } = useConfigStore();
 
   const {
@@ -245,27 +246,41 @@ export default function Custom() {
     router.push('/compass-help');
   }, [router]);
 
+  const handleCompassToggle = useCallback(() => {
+    if (compassVisible) {
+      // Hide compass
+      setCompassVisible(false);
+    } else {
+      // Show compass and open help sheet
+      setCompassVisible(true);
+      router.push('/compass-help');
+    }
+  }, [compassVisible, router]);
+
   return (
     <>
       <Stack.Screen.BackButton displayMode="minimal" />
       <Stack.Toolbar placement="right">
+        <Stack.Toolbar.Button icon="location.north.circle" onPress={handleCompassToggle} />
         <Stack.Toolbar.Button onPress={() => {}}>
           <Stack.Toolbar.Icon sf="link" />
           {unlinkedCount > 0 && (
             <Stack.Toolbar.Badge>{String(unlinkedCount)}</Stack.Toolbar.Badge>
           )}
         </Stack.Toolbar.Button>
-        <Stack.Toolbar.Button icon="location" onPress={handleSnapToOrigin} />
+        <Stack.Toolbar.Button icon="scope" onPress={handleSnapToOrigin} />
       </Stack.Toolbar>
       {isWizardMode && <WizardProgress currentStep={3} />}
       <View style={[styles.container, { backgroundColor: colors.background.secondary }]} onLayout={handleLayout} testID="canvas-container">
-        <View style={styles.compassContainer}>
-          <Compass
-            direction={config.compassDirection}
-            onDirectionChange={updateCompassDirection}
-            onTap={handleCompassTap}
-          />
-        </View>
+        {compassVisible && (
+          <View style={styles.compassContainer}>
+            <Compass
+              direction={config.compassDirection}
+              onDirectionChange={updateCompassDirection}
+              onTap={handleCompassTap}
+            />
+          </View>
+        )}
         <SolarPanelCanvas
           panels={panels}
           selectedId={selectedId}
@@ -315,7 +330,7 @@ const styles = StyleSheet.create({
   compassContainer: {
     position: "absolute",
     top: 16,
-    right: 16,
+    right: 48,
     zIndex: 10,
   },
 });

--- a/src/app/custom.tsx
+++ b/src/app/custom.tsx
@@ -7,6 +7,7 @@ import * as Haptics from "expo-haptics";
 import { useConfigStore } from "@/hooks/useConfigStore";
 import { SolarPanelCanvas } from "@/components/SolarPanelCanvas";
 import { ZoomControls } from "@/components/ZoomControls";
+import { Compass } from "@/components/Compass";
 import { usePanelsContext } from "@/contexts/PanelsContext";
 import { PANEL_WIDTH, PANEL_HEIGHT } from "@/utils/panelUtils";
 import { GRID_SIZE } from "@/utils/gridSnap";
@@ -114,7 +115,7 @@ export default function Custom() {
   const canvasHeight = useSharedValue(0);
   const hasInitialized = useRef(false);
   const [zoomIndex, setZoomIndex] = useState(DEFAULT_ZOOM_INDEX);
-  const { config, setWizardCompleted } = useConfigStore();
+  const { config, setWizardCompleted, updateCompassDirection } = useConfigStore();
 
   const {
     panels,
@@ -240,6 +241,10 @@ export default function Custom() {
     }
   }, [zoomIndex, scale]);
 
+  const handleCompassTap = useCallback(() => {
+    router.push('/compass-help');
+  }, [router]);
+
   return (
     <>
       <Stack.Screen.BackButton displayMode="minimal" />
@@ -254,6 +259,13 @@ export default function Custom() {
       </Stack.Toolbar>
       {isWizardMode && <WizardProgress currentStep={3} />}
       <View style={[styles.container, { backgroundColor: colors.background.secondary }]} onLayout={handleLayout} testID="canvas-container">
+        <View style={styles.compassContainer}>
+          <Compass
+            direction={config.compassDirection}
+            onDirectionChange={updateCompassDirection}
+            onTap={handleCompassTap}
+          />
+        </View>
         <SolarPanelCanvas
           panels={panels}
           selectedId={selectedId}
@@ -299,5 +311,11 @@ export default function Custom() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  compassContainer: {
+    position: "absolute",
+    top: 16,
+    right: 16,
+    zIndex: 10,
   },
 });

--- a/src/app/inverter-details.tsx
+++ b/src/app/inverter-details.tsx
@@ -1,5 +1,5 @@
 import {useState, useCallback} from 'react';
-import {StyleSheet, View, Keyboard, TouchableWithoutFeedback} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router';
 import * as Haptics from 'expo-haptics';
 import {useConfigStore} from '@/hooks/useConfigStore';
@@ -15,6 +15,7 @@ import {
 import {
   bold,
   scrollDismissesKeyboard,
+  submitLabel,
 } from '@expo/ui/swift-ui/modifiers';
 
 function generateSerialNumber(): string {
@@ -90,10 +91,9 @@ export default function InverterDetailsScreen() {
       <Stack.Toolbar placement="right">
         <Stack.Toolbar.Button icon="checkmark" onPress={handleSave} />
       </Stack.Toolbar>
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <View style={styles.container}>
-          <Host style={styles.host}>
-            <Form modifiers={[scrollDismissesKeyboard('interactively')]}>
+      <View style={styles.container}>
+        <Host style={styles.host}>
+            <Form modifiers={[scrollDismissesKeyboard('immediately')]}>
               {/* Serial Number Section */}
               <Section header={<Text>Details</Text>}>
                 <LabeledContent label="Serial Number">
@@ -101,7 +101,8 @@ export default function InverterDetailsScreen() {
                     defaultValue={serial}
                     onChangeText={setSerial}
                     placeholder="Enter serial number"
-                    keyboardType="numeric"
+                    keyboardType="numbers-and-punctuation"
+                    modifiers={[submitLabel('done')]}
                   />
                 </LabeledContent>
               </Section>
@@ -130,7 +131,6 @@ export default function InverterDetailsScreen() {
             </Form>
           </Host>
         </View>
-      </TouchableWithoutFeedback>
     </>
   );
 }

--- a/src/app/production.tsx
+++ b/src/app/production.tsx
@@ -9,6 +9,7 @@ import { usePanelsContext } from "@/contexts/PanelsContext";
 import { useConfigStore } from "@/hooks/useConfigStore";
 import { ProductionCanvas } from "@/components/ProductionCanvas";
 import { ZoomControls } from "@/components/ZoomControls";
+import { Compass } from "@/components/Compass";
 import { ZOOM_LEVELS, DEFAULT_ZOOM_INDEX } from "@/utils/zoomConstants";
 import { PANEL_WIDTH, PANEL_HEIGHT } from "@/utils/panelUtils";
 import { useColors } from "@/utils/theme";
@@ -230,6 +231,9 @@ export default function ProductionScreen() {
           </Text>
         </View>
         <View style={styles.canvasContainer} onLayout={handleLayout}>
+          <View style={styles.compassContainer}>
+            <Compass direction={config.compassDirection} readOnly />
+          </View>
           <ProductionCanvas
             panels={panels}
             wattages={new Map(Object.entries(wattages))}
@@ -258,5 +262,11 @@ const styles = StyleSheet.create({
   },
   canvasContainer: {
     flex: 1,
+  },
+  compassContainer: {
+    position: "absolute",
+    top: 16,
+    right: 16,
+    zIndex: 10,
   },
 });

--- a/src/components/Compass.tsx
+++ b/src/components/Compass.tsx
@@ -26,7 +26,7 @@ interface CompassProps {
 // Snap to nearest 45 degree increment
 function snapToDirection(degrees: number): number {
   "worklet";
-  return Math.round(degrees / 45) * 45 % 360;
+  return (Math.round(degrees / 45) * 45) % 360;
 }
 
 export function Compass({
@@ -115,10 +115,12 @@ export function Compass({
     });
 
   // Tap gesture for opening help sheet
-  const tapGesture = Gesture.Tap().onEnd(() => {
-    scheduleOnRN(triggerHaptic);
-    scheduleOnRN(handleTap);
-  });
+  const tapGesture = Gesture.Tap()
+    .enabled(!readOnly)
+    .onEnd(() => {
+      scheduleOnRN(triggerHaptic);
+      scheduleOnRN(handleTap);
+    });
 
   const composedGesture = Gesture.Exclusive(panGesture, tapGesture);
 

--- a/src/components/Compass.tsx
+++ b/src/components/Compass.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useEffect } from "react";
+import { StyleSheet, View } from "react-native";
+import {
+  Canvas,
+  Group,
+  Line,
+  Path,
+  Text as SkiaText,
+  matchFont,
+  Skia,
+} from "@shopify/react-native-skia";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import {
+  useSharedValue,
+  useDerivedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+import * as Haptics from "expo-haptics";
+import { useColors } from "@/utils/theme";
+
+// Larger size to fit labels
+const COMPASS_SIZE = 80;
+const CENTER = COMPASS_SIZE / 2;
+const RING_RADIUS = 24;
+
+// Arrow dimensions
+// Outer triangle (pointing up)
+const OUTER_TOP = -16;       // Top point (apex) relative to center
+const OUTER_BASE = 12;       // Base Y relative to center
+const BOTTOM_NOTCH = 6;     // Indent for bottom point of arrow to create notch
+const OUTER_HALF_WIDTH = 12;  // Half of base width
+
+// 8 dash segments (2 between each cardinal direction)
+const DASH_COUNT = 8;
+const DASH_ANGLE = (2 * Math.PI) / DASH_COUNT;
+const DASH_LENGTH = 0.5; // Portion of each segment that is filled
+
+interface CompassProps {
+  direction: number;
+  onDirectionChange?: (degrees: number) => void;
+  onTap?: () => void;
+  readOnly?: boolean;
+}
+
+// Snap to nearest 45 degree increment
+function snapToDirection(degrees: number): number {
+  "worklet";
+  return Math.round(degrees / 45) * 45 % 360;
+}
+
+export function Compass({
+  direction,
+  onDirectionChange,
+  onTap,
+  readOnly = false,
+}: CompassProps) {
+  const colors = useColors();
+  const angle = useSharedValue(direction);
+
+  // Sync with external direction prop
+  useEffect(() => {
+    angle.value = direction;
+  }, [direction, angle]);
+
+  const font = matchFont({
+    fontFamily: "System",
+    fontSize: 11,
+    fontWeight: "600",
+  });
+
+  // Create arrow path: outer triangle with inner diamond cutout (even-odd fill)
+  const arrowPath = useDerivedValue(() => {
+    const path = Skia.Path.Make();
+
+    // Outer triangle (arrow shape)
+    path.moveTo(CENTER, CENTER + OUTER_TOP);                     // Top point of arrow
+    path.lineTo(CENTER - OUTER_HALF_WIDTH, CENTER + OUTER_BASE); // Bottom left of arrow
+    path.lineTo(CENTER, CENTER + OUTER_BASE - BOTTOM_NOTCH);     // Bottom center of arrow notch
+    path.lineTo(CENTER + OUTER_HALF_WIDTH, CENTER + OUTER_BASE); // Bottom right of arrow
+    path.close();
+
+    // Inner cutout triangle
+    path.moveTo(CENTER, CENTER - 9);                            // Top point of triangle
+    path.lineTo(CENTER - 6, CENTER + 6);                        // Bottom left of triangle
+    path.lineTo(CENTER, CENTER + 3);                             // Bottom right of triangle
+    path.close();
+
+    // Even-odd fill rule makes the inner region transparent
+    path.setFillType(1); // 1 = EvenOdd in Skia
+    return path;
+  });
+
+  // Transform for rotating the arrow
+  const arrowTransform = useDerivedValue(() => [
+    { translateX: CENTER },
+    { translateY: CENTER },
+    { rotate: (angle.value * Math.PI) / 180 },
+    { translateX: -CENTER },
+    { translateY: -CENTER },
+  ]);
+
+  const triggerHaptic = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  }, []);
+
+  const handleDirectionChange = useCallback(
+    (degrees: number) => {
+      onDirectionChange?.(degrees);
+    },
+    [onDirectionChange]
+  );
+
+  const handleTap = useCallback(() => {
+    onTap?.();
+  }, [onTap]);
+
+  // Pan gesture for rotation
+  const panGesture = Gesture.Pan()
+    .enabled(!readOnly)
+    .onUpdate((e) => {
+      // Calculate angle from center to touch point
+      const dx = e.x - CENTER;
+      const dy = e.y - CENTER;
+      const rawAngle = Math.atan2(dx, -dy); // -dy because y increases downward, we want 0° at top
+      const degrees = ((rawAngle * 180) / Math.PI + 360) % 360;
+      angle.value = degrees;
+    })
+    .onEnd(() => {
+      // Snap to nearest 45 degrees
+      const snapped = snapToDirection(angle.value);
+      angle.value = withTiming(snapped, { duration: 150 });
+      scheduleOnRN(triggerHaptic);
+      scheduleOnRN(handleDirectionChange, snapped);
+    });
+
+  // Tap gesture for opening help sheet
+  const tapGesture = Gesture.Tap().onEnd(() => {
+    scheduleOnRN(triggerHaptic);
+    scheduleOnRN(handleTap);
+  });
+
+  const composedGesture = Gesture.Exclusive(panGesture, tapGesture);
+
+  // Generate 8 dash segments for the ring (offset to be between cardinal directions)
+  const dashSegments = [];
+  for (let i = 0; i < DASH_COUNT; i++) {
+    // Offset by half a segment so dashes are between letters
+    const startAngle = i * DASH_ANGLE - Math.PI / 2 + DASH_ANGLE / 2;
+    const endAngle = startAngle + DASH_ANGLE * DASH_LENGTH;
+    const x1 = CENTER + RING_RADIUS * Math.cos(startAngle);
+    const y1 = CENTER + RING_RADIUS * Math.sin(startAngle);
+    const x2 = CENTER + RING_RADIUS * Math.cos(endAngle);
+    const y2 = CENTER + RING_RADIUS * Math.sin(endAngle);
+    dashSegments.push({ x1, y1, x2, y2, key: i });
+  }
+
+  // Cardinal label positions (outside ring)
+  const labelRadius = RING_RADIUS + 10;
+  const labels = [
+    { text: "N", angle: -Math.PI / 2 },
+    { text: "E", angle: 0 },
+    { text: "S", angle: Math.PI / 2 },
+    { text: "W", angle: Math.PI },
+  ];
+
+  return (
+    <GestureDetector gesture={composedGesture}>
+      <View style={styles.container}>
+        <Canvas style={styles.canvas}>
+          {/* Dashed ring */}
+          {dashSegments.map((seg) => (
+            <Line
+              key={seg.key}
+              p1={{ x: seg.x1, y: seg.y1 }}
+              p2={{ x: seg.x2, y: seg.y2 }}
+              color={colors.border.medium}
+              strokeWidth={2}
+              style="stroke"
+              strokeCap="round"
+            />
+          ))}
+
+          {/* Cardinal labels */}
+          {font &&
+            labels.map((label) => {
+              const x = CENTER + labelRadius * Math.cos(label.angle);
+              const y = CENTER + labelRadius * Math.sin(label.angle);
+              const textWidth = font.measureText(label.text).width;
+              return (
+                <SkiaText
+                  key={label.text}
+                  x={x - textWidth / 2}
+                  y={y + 4} // Adjust for baseline
+                  text={label.text}
+                  font={font}
+                  color={label.text === "N" ? colors.text.primary : colors.text.secondary}
+                />
+              );
+            })}
+
+          {/* Rotating arrow - filled triangle */}
+          <Group transform={arrowTransform}>
+            <Path
+              path={arrowPath}
+              color={colors.text.primary}
+              style="fill"
+            />
+          </Group>
+        </Canvas>
+      </View>
+    </GestureDetector>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: COMPASS_SIZE,
+    height: COMPASS_SIZE,
+  },
+  canvas: {
+    flex: 1,
+  },
+});

--- a/src/components/Compass.tsx
+++ b/src/components/Compass.tsx
@@ -14,7 +14,6 @@ const RING_RADIUS = 24;
 
 // 4 curved arc segments at diagonal positions (NE, SE, SW, NW)
 // Letters N, E, S, W are positioned between the arcs on the ring
-const ARC_COUNT = 4;
 const ARC_SWEEP = 40; // Arc span in degrees (leaves wider gaps for letters)
 
 interface CompassProps {

--- a/src/components/Compass.tsx
+++ b/src/components/Compass.tsx
@@ -12,10 +12,10 @@ const COMPASS_SIZE = 80;
 const CENTER = COMPASS_SIZE / 2;
 const RING_RADIUS = 24;
 
-// 8 curved arc segments (positioned between cardinal directions)
-const DASH_COUNT = 8;
-const SEGMENT_ANGLE = 360 / DASH_COUNT; // 45° per segment
-const ARC_SWEEP = 20; // Visible arc span in degrees (with gaps between)
+// 4 curved arc segments at diagonal positions (NE, SE, SW, NW)
+// Letters N, E, S, W are positioned between the arcs on the ring
+const ARC_COUNT = 4;
+const ARC_SWEEP = 40; // Arc span in degrees (leaves wider gaps for letters)
 
 interface CompassProps {
   direction: number;
@@ -123,7 +123,7 @@ export function Compass({
 
   const composedGesture = Gesture.Exclusive(panGesture, tapGesture);
 
-  // Generate 8 curved arc segments for the ring (positioned between cardinal directions)
+  // Generate 4 curved arc segments at diagonal positions (NE, SE, SW, NW)
   // Skia angles: 0° = right (East), 90° = down (South), 180° = left (West), 270° = up (North)
   const oval = Skia.XYWHRect(
     CENTER - RING_RADIUS,
@@ -132,21 +132,20 @@ export function Compass({
     RING_RADIUS * 2
   );
 
-  const arcPaths = [];
-  for (let i = 0; i < DASH_COUNT; i++) {
-    // Start at -90° (North/top) and offset by half segment so arcs are between letters
-    const startAngle = -90 + (i * SEGMENT_ANGLE) + (SEGMENT_ANGLE - ARC_SWEEP) / 2;
-    const path = Skia.Path.Make().addArc(oval, startAngle, ARC_SWEEP);
-    arcPaths.push({ path, key: i });
-  }
+  // Arcs centered at diagonals: -45° (NE), 45° (SE), 135° (SW), 225° (NW)
+  const arcStartAngles = [-45, 45, 135, 225].map(a => a - ARC_SWEEP / 2);
+  const arcPaths = arcStartAngles.map((startAngle, i) => ({
+    path: Skia.Path.Make().addArc(oval, startAngle, ARC_SWEEP),
+    key: i,
+  }));
 
-  // Cardinal label positions (outside ring)
-  const labelRadius = RING_RADIUS + 10;
+  // Cardinal labels positioned ON the ring (between arcs)
+  const labelRadius = RING_RADIUS;
   const labels = [
-    { text: "N", angle: -Math.PI / 2 },
-    { text: "E", angle: 0 },
-    { text: "S", angle: Math.PI / 2 },
-    { text: "W", angle: Math.PI },
+    { text: "N", angle: -Math.PI / 2 },  // Top
+    { text: "E", angle: 0 },              // Right
+    { text: "S", angle: Math.PI / 2 },    // Bottom
+    { text: "W", angle: Math.PI },        // Left
   ];
 
   return (

--- a/src/hooks/useConfigStore.ts
+++ b/src/hooks/useConfigStore.ts
@@ -9,6 +9,7 @@ import {
   removeInverter as deleteInverter,
   getWizardCompleted,
   setWizardCompleted,
+  updateCompassDirection as updateDirection,
   subscribe,
   SystemConfig,
 } from '@/utils/configStore';
@@ -38,5 +39,6 @@ export function useConfigStore() {
     removeInverter: (inverterId: string) => deleteInverter(inverterId),
     getWizardCompleted: () => getWizardCompleted(),
     setWizardCompleted: (completed: boolean) => setWizardCompleted(completed),
+    updateCompassDirection: (degrees: number) => updateDirection(degrees),
   };
 }

--- a/src/utils/configStore.ts
+++ b/src/utils/configStore.ts
@@ -17,12 +17,14 @@ export interface SystemConfig {
   defaultMaxWattage: number;
   inverters: InverterConfig[];
   wizardCompleted: boolean;
+  compassDirection: number; // 0-360 degrees, 0 = North
 }
 
 // Default configuration: 14 inverters with realistic efficiency distribution
 const DEFAULT_CONFIG: SystemConfig = {
   defaultMaxWattage: 430,
   wizardCompleted: false,
+  compassDirection: 0, // Default to North
   inverters: [
     // 7 inverters at 95% (optimal)
     { id: '1', serialNumber: generateSerialNumber(), efficiency: 95 },
@@ -70,6 +72,11 @@ function loadConfig(): void {
       // Migrate: ensure wizardCompleted field exists
       if (currentConfig.wizardCompleted === undefined) {
         currentConfig.wizardCompleted = false;
+        needsSave = true;
+      }
+      // Migrate: ensure compassDirection field exists
+      if (currentConfig.compassDirection === undefined) {
+        currentConfig.compassDirection = 0;
         needsSave = true;
       }
       if (needsSave) {
@@ -196,6 +203,15 @@ export function getWizardCompleted(): boolean {
 export function setWizardCompleted(completed: boolean): void {
   const newConfig = getConfig();
   newConfig.wizardCompleted = completed;
+  updateConfig(newConfig);
+}
+
+/**
+ * Update compass direction (0-360 degrees, 0 = North)
+ */
+export function updateCompassDirection(degrees: number): void {
+  const newConfig = getConfig();
+  newConfig.compassDirection = ((degrees % 360) + 360) % 360; // Normalize to 0-359
   updateConfig(newConfig);
 }
 


### PR DESCRIPTION
## Summary

- Add interactive compass component to indicate solar panel array orientation
- Compass uses Skia for rendering with curved arc segments and arrow with triangle cutout
- On Custom screen: toggle visibility via toolbar button, opens help sheet on first show
- On Production screen: always visible as read-only indicator
- Direction persists to config store (0-360°, snaps to 8 directions)

## Changes

- **New components**: `Compass.tsx`, `compass-help.tsx` form sheet
- **Config store**: Added `compassDirection` field and `updateCompassDirection()` function
- **Custom screen**: Compass toggle button in toolbar, conditionally renders compass
- **Production screen**: Always shows read-only compass
- **Documentation**: Updated README.md and CLAUDE.md

## Test plan

- [ ] Custom screen: Tap compass button → help sheet opens, compass appears
- [ ] Custom screen: Drag compass arrow → snaps to 8 directions with haptic
- [ ] Custom screen: Tap compass button again → compass hides
- [ ] Production screen: Compass always visible showing saved direction
- [ ] Direction persists after app restart

🤖 Generated with [Claude Code](https://claude.ai/code)