### PR TITLE
Refactor AI model usage: multi-model comparison & grid layout

### DIFF
--- a/.maestro/analyze-skip.yaml
+++ b/.maestro/analyze-skip.yaml
@@ -1,0 +1,47 @@
+appId: com.bkomen.reactnativearraylayout2
+---
+# Analyze Screen: Verify model selector UI and Skip action
+# Tests: Upload → pick photo from gallery → Analyze screen (model selector) → Skip → Custom
+
+- runFlow: shared/launch-fresh.yaml
+
+# Navigate wizard to Upload screen
+- tapOn:
+    id: "get-started-button"
+- extendedWaitUntil:
+    visible: "Panel Settings"
+    timeout: 10000
+- tapOn: "Continue"
+- extendedWaitUntil:
+    visible: "Take or Select Photo"
+    timeout: 10000
+
+# Open gallery picker
+- tapOn:
+    id: "choose-gallery-button"
+
+# Wait for the system photo picker to appear
+- extendedWaitUntil:
+    visible: "Photos"
+    timeout: 10000
+
+# Tap the first photo in the grid (top-left area)
+- tapOn:
+    point: "17%,25%"
+
+# Verify we land on the Analyze screen with model selector
+- extendedWaitUntil:
+    visible: "Select AI Model"
+    timeout: 15000
+
+# Verify model list (Sonnet row includes "Default" badge in accessibility text)
+- assertVisible: "Claude Sonnet 4.6, Default"
+- assertVisible: "Claude Opus 4.6"
+- assertVisible: "Amazon Nova Pro"
+
+# Skip to Custom screen instead of analyzing
+- tapOn: "Skip"
+- extendedWaitUntil:
+    visible:
+        id: "canvas-container"
+    timeout: 10000

--- a/.maestro/analyze-skip.yaml
+++ b/.maestro/analyze-skip.yaml
@@ -34,8 +34,8 @@ appId: com.bkomen.reactnativearraylayout2
     visible: "Select AI Model"
     timeout: 15000
 
-# Verify model list (Sonnet row includes "Default" badge in accessibility text)
-- assertVisible: "Claude Sonnet 4.6, Default"
+# Verify model list (Sonnet row includes "(Default)" in label text)
+- assertVisible: "Claude Sonnet 4.6 (Default)"
 - assertVisible: "Claude Opus 4.6"
 - assertVisible: "Amazon Nova Pro"
 

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "wgpu-matrix": "^3.0.2",
       },
       "devDependencies": {
+        "@types/bun": "^1.3.9",
         "@types/node": "^25.2.3",
         "@types/react": "~19.2.2",
         "@types/three": "0.172.0",
@@ -511,6 +512,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
@@ -720,6 +723,8 @@
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,6 @@
         "react-native-wgpu": "^0.4.1",
         "react-native-worklets": "0.7.2",
         "three": "0.172.0",
-        "undici": "^7.21.0",
         "wgpu-matrix": "^3.0.2",
       },
       "devDependencies": {
@@ -1689,8 +1688,6 @@
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": "script/cli.js" }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
-
-    "undici": ["undici@7.21.0", "", {}, "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@ai-sdk/amazon-bedrock": "^4.0.50",
     "@expo/ui": "~55.0.0-preview.4",
     "@expo/vector-icons": "^15.0.3",
+    "@react-three/fiber": "^9.4.0",
     "@shopify/react-native-skia": "2.4.14",
     "ai": "^6.0.74",
     "expo": "55.0.0-preview.9",
@@ -46,8 +47,6 @@
     "react-native-wgpu": "^0.4.1",
     "react-native-worklets": "0.7.2",
     "three": "0.172.0",
-    "@react-three/fiber": "^9.4.0",
-    "undici": "^7.21.0",
     "wgpu-matrix": "^3.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "wgpu-matrix": "^3.0.2"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.9",
     "@types/node": "^25.2.3",
     "@types/react": "~19.2.2",
     "@types/three": "0.172.0",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -34,6 +34,12 @@ export default function RootLayout() {
               }}
             />
             <Stack.Screen
+              name="analyze"
+              options={{
+                title: "",
+              }}
+            />
+            <Stack.Screen
               name="custom"
               options={{
                 title: "",

--- a/src/app/analyze.tsx
+++ b/src/app/analyze.tsx
@@ -1,0 +1,432 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  Text,
+  ScrollView,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
+import { Stack, useRouter, useLocalSearchParams } from "expo-router";
+import { Image } from "expo-image";
+import * as Haptics from "expo-haptics";
+import { ProcessingOverlay } from "@/components/ProcessingOverlay";
+import { AnalysisPreview } from "@/components/AnalysisPreview";
+import { WizardProgress } from "@/components/WizardProgress";
+import { Button } from "@/components/Button";
+import { resizeForAnalysis } from "@/utils/imageResize";
+import { setAnalysisResult } from "@/utils/analysisStore";
+import { useColors } from "@/utils/theme";
+
+interface PanelResult {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: 0 | 90;
+  label: string;
+}
+
+interface AnalysisResponse {
+  panels: PanelResult[];
+  reasoning: string | null;
+  model: string;
+}
+
+interface ResizedImage {
+  base64: string;
+  mimeType: "image/jpeg";
+  width: number;
+  height: number;
+}
+
+type Phase = "select_model" | "processing" | "results";
+
+const MODELS: { id: string; name: string; isDefault: boolean }[] = [
+  { id: "us.anthropic.claude-sonnet-4-6-v1", name: "Claude Sonnet 4.6", isDefault: true },
+  { id: "us.anthropic.claude-opus-4-6-v1", name: "Claude Opus 4.6", isDefault: false },
+  { id: "us.amazon.nova-pro-v1:0", name: "Amazon Nova Pro", isDefault: false },
+  { id: "us.amazon.nova-premier-v1:0", name: "Amazon Nova Premier", isDefault: false },
+  { id: "us.mistral.pixtral-large-2502-v1:0", name: "Mistral Pixtral Large", isDefault: false },
+  { id: "us.meta.llama4-maverick-17b-instruct-v1:0", name: "Meta Llama 4 Maverick 17B", isDefault: false },
+  { id: "us.meta.llama3-2-90b-instruct-v1:0", name: "Meta Llama 3.2 90B Vision", isDefault: false },
+];
+
+export default function Analyze() {
+  const router = useRouter();
+  const { imageUri, wizard } = useLocalSearchParams<{
+    imageUri: string;
+    wizard?: string;
+  }>();
+  const isWizardMode = wizard === "true";
+  const colors = useColors();
+
+  const [phase, setPhase] = useState<Phase>("select_model");
+  const [selectedModel, setSelectedModel] = useState(MODELS[0].id);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<AnalysisResponse | null>(null);
+  const [reasoningExpanded, setReasoningExpanded] = useState(false);
+  const resizedRef = useRef<ResizedImage | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const decodedUri = decodeURIComponent(imageUri ?? "");
+
+  const handleSkip = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    const wizardParam = isWizardMode ? "?wizard=true" : "";
+    router.push(`/custom${wizardParam}`);
+  };
+
+  const handleAnalyze = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setPhase("processing");
+    setError(null);
+
+    try {
+      // Resize once, cache for retries
+      if (!resizedRef.current) {
+        resizedRef.current = await resizeForAnalysis(decodedUri);
+      }
+      const resized = resizedRef.current;
+
+      const response = await fetch("/api/analyze", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          image: resized.base64,
+          mimeType: resized.mimeType,
+          model: selectedModel,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        let errorMessage = `Server error: ${response.status}`;
+        try {
+          const body = await response.json();
+          if (body.error) errorMessage = body.error;
+        } catch {
+          // ignore JSON parse error
+        }
+        throw new Error(errorMessage);
+      }
+
+      const data: AnalysisResponse = await response.json();
+      setResult(data);
+      setPhase("results");
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === "AbortError") return;
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
+      setPhase("select_model");
+    }
+  }, [decodedUri, selectedModel]);
+
+  const handleRetry = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setResult(null);
+    setReasoningExpanded(false);
+    setPhase("select_model");
+  };
+
+  const handleContinue = () => {
+    if (!result || !resizedRef.current) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+
+    setAnalysisResult({
+      panels: result.panels,
+      imageWidth: resizedRef.current.width,
+      imageHeight: resizedRef.current.height,
+    });
+
+    const customRoute = isWizardMode
+      ? "/custom?initialPanels=true&wizard=true"
+      : "/custom?initialPanels=true";
+    router.replace(customRoute);
+  };
+
+  const modelName = MODELS.find((m) => m.id === (result?.model ?? selectedModel))?.name ?? "Unknown";
+
+  return (
+    <>
+      <Stack.Screen.BackButton displayMode="minimal" />
+      {isWizardMode && <WizardProgress currentStep={2} />}
+
+      {phase === "processing" && <ProcessingOverlay imageUri={decodedUri} />}
+
+      {phase !== "processing" && (
+        <ScrollView
+          contentInsetAdjustmentBehavior="automatic"
+          style={{ backgroundColor: colors.background.primary }}
+          contentContainerStyle={styles.scrollContent}
+        >
+          {phase === "select_model" && (
+            <>
+              {/* Image preview */}
+              <View style={styles.imageContainer}>
+                <Image
+                  source={{ uri: decodedUri }}
+                  style={styles.imagePreview}
+                  contentFit="contain"
+                />
+              </View>
+
+              {/* Error banner */}
+              {error && (
+                <View style={[styles.errorBanner, { backgroundColor: "#FEE2E2" }]}>
+                  <Text style={styles.errorText}>{error}</Text>
+                </View>
+              )}
+
+              {/* Model selector */}
+              <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
+                Select AI Model
+              </Text>
+
+              <View style={styles.modelList}>
+                {MODELS.map((model) => {
+                  const isSelected = selectedModel === model.id;
+                  return (
+                    <Pressable
+                      key={model.id}
+                      onPress={() => {
+                        Haptics.selectionAsync();
+                        setSelectedModel(model.id);
+                      }}
+                      style={[
+                        styles.modelRow,
+                        {
+                          backgroundColor: isSelected
+                            ? colors.primaryLight
+                            : colors.background.secondary,
+                          borderColor: isSelected
+                            ? colors.primary
+                            : colors.border.light,
+                        },
+                      ]}
+                    >
+                      <View
+                        style={[
+                          styles.radio,
+                          {
+                            borderColor: isSelected
+                              ? colors.primary
+                              : colors.border.medium,
+                          },
+                        ]}
+                      >
+                        {isSelected && (
+                          <View
+                            style={[
+                              styles.radioInner,
+                              { backgroundColor: colors.primary },
+                            ]}
+                          />
+                        )}
+                      </View>
+                      <Text
+                        style={[
+                          styles.modelName,
+                          {
+                            color: colors.text.primary,
+                            fontWeight: isSelected ? "600" : "400",
+                          },
+                        ]}
+                      >
+                        {model.name}
+                      </Text>
+                      {model.isDefault && (
+                        <View style={[styles.badge, { backgroundColor: colors.primary }]}>
+                          <Text style={[styles.badgeText, { color: colors.text.inverse }]}>
+                            Default
+                          </Text>
+                        </View>
+                      )}
+                    </Pressable>
+                  );
+                })}
+              </View>
+
+              <Button
+                title="Analyze"
+                onPress={handleAnalyze}
+                style={{ width: "100%" }}
+              />
+            </>
+          )}
+
+          {phase === "results" && result && resizedRef.current && (
+            <>
+              {/* Analysis preview with red boxes */}
+              <AnalysisPreview
+                imageUri={resizedRef.current.base64.startsWith("data:")
+                  ? resizedRef.current.base64
+                  : `data:image/jpeg;base64,${resizedRef.current.base64}`}
+                imageWidth={resizedRef.current.width}
+                imageHeight={resizedRef.current.height}
+                panels={result.panels}
+              />
+
+              {/* Info badges */}
+              <View style={styles.badgeRow}>
+                <View style={[styles.infoBadge, { backgroundColor: colors.primaryLight }]}>
+                  <Text style={[styles.infoBadgeText, { color: colors.primary }]}>
+                    {result.panels.length} panel{result.panels.length !== 1 ? "s" : ""} detected
+                  </Text>
+                </View>
+                <View style={[styles.infoBadge, { backgroundColor: colors.background.tertiary }]}>
+                  <Text style={[styles.infoBadgeText, { color: colors.text.secondary }]}>
+                    {modelName}
+                  </Text>
+                </View>
+              </View>
+
+              {/* Reasoning */}
+              {result.reasoning && (
+                <View style={styles.reasoningContainer}>
+                  <Text
+                    style={[styles.reasoningText, { color: colors.text.secondary }]}
+                    numberOfLines={reasoningExpanded ? undefined : 3}
+                  >
+                    {result.reasoning}
+                  </Text>
+                  <Pressable onPress={() => setReasoningExpanded(!reasoningExpanded)}>
+                    <Text style={[styles.showMoreText, { color: colors.primary }]}>
+                      {reasoningExpanded ? "Show less" : "Show more"}
+                    </Text>
+                  </Pressable>
+                </View>
+              )}
+
+              {/* Action buttons */}
+              <View style={styles.buttonRow}>
+                <Button
+                  title="Retry"
+                  variant="outlined"
+                  onPress={handleRetry}
+                  style={{ flex: 1 }}
+                />
+                <Button
+                  title="Continue"
+                  onPress={handleContinue}
+                  style={{ flex: 1 }}
+                />
+              </View>
+            </>
+          )}
+        </ScrollView>
+      )}
+
+      {isWizardMode && phase !== "processing" && (
+        <Stack.Toolbar placement="bottom">
+          <Stack.Toolbar.Button onPress={handleSkip}>
+            Skip
+          </Stack.Toolbar.Button>
+        </Stack.Toolbar>
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    alignItems: "stretch",
+    gap: 16,
+    paddingHorizontal: 24,
+    paddingVertical: 24,
+  },
+  imageContainer: {
+    borderRadius: 12,
+    overflow: "hidden",
+    alignSelf: "center",
+    width: "100%",
+    maxHeight: 200,
+  },
+  imagePreview: {
+    width: "100%",
+    height: 200,
+  },
+  errorBanner: {
+    padding: 12,
+    borderRadius: 8,
+  },
+  errorText: {
+    color: "#DC2626",
+    fontSize: 14,
+    textAlign: "center",
+  },
+  sectionTitle: {
+    fontSize: 17,
+    fontWeight: "600",
+    marginTop: 8,
+  },
+  modelList: {
+    gap: 8,
+  },
+  modelRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 14,
+    borderRadius: 10,
+    borderWidth: 1,
+    gap: 12,
+  },
+  radio: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  radioInner: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  modelName: {
+    fontSize: 16,
+    flex: 1,
+  },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+  },
+  badgeText: {
+    fontSize: 11,
+    fontWeight: "600",
+  },
+  badgeRow: {
+    flexDirection: "row",
+    gap: 8,
+    flexWrap: "wrap",
+  },
+  infoBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  infoBadgeText: {
+    fontSize: 13,
+    fontWeight: "500",
+  },
+  reasoningContainer: {
+    gap: 4,
+  },
+  reasoningText: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  showMoreText: {
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: 12,
+    marginTop: 8,
+  },
+});

--- a/src/app/api/analyze+api.ts
+++ b/src/app/api/analyze+api.ts
@@ -45,7 +45,7 @@ interface AnalyzeResponse {
   panels: PanelResult[];
 }
 
-const SYSTEM_PROMPT = `You are a solar panel array analyzer. You receive photos of solar panel installations and identify each individual panel.
+const SYSTEM_PROMPT = `You are a solar panel array layout analyzer. You receive photos of solar panel installation plans, a drawing of a roof with stickers for each solar panel/micro-inverter, and identify each individual panel/micro-inverter.
 
 Return a JSON object with this exact structure:
 {

--- a/src/app/api/analyze+api.ts
+++ b/src/app/api/analyze+api.ts
@@ -64,8 +64,8 @@ Return a JSON object with this exact structure:
 
 Rules:
 - reasoning: Briefly describe what you see in the image and any challenges identifying panels or labels
-- x, y: position of the panel's top-left corner in pixel coordinates relative to the image
-- width, height: panel dimensions in pixels
+- x, y: CENTER point of the panel in pixel coordinates relative to the image (not the top-left corner)
+- width, height: approximate panel dimensions in pixels
 - rotation: 0 for portrait (taller than wide), 90 for landscape (wider than tall)
 - label: Look for serial numbers on micro-inverter labels attached to each panel. Serial numbers are typically alphanumeric codes like "G25309101383" (letter(s) followed by digits). If you see a label but can only read part of the serial number, include what you can read. Use "" only if no label or serial number is visible at all.
 - Return ONLY valid JSON, no markdown fences, no explanation outside the JSON.`;

--- a/src/app/custom.tsx
+++ b/src/app/custom.tsx
@@ -55,11 +55,11 @@ function mapAnalysisToCanvasPositions(
 ) {
   if (panels.length === 0) return [];
 
-  // Compute center points for each panel
+  // AI returns center points directly as x, y
   const withCenters = panels.map((p, i) => ({
     index: i,
-    cx: p.x + p.width / 2,
-    cy: p.y + p.height / 2,
+    cx: p.x,
+    cy: p.y,
     rotation: p.rotation,
   }));
 

--- a/src/app/upload.tsx
+++ b/src/app/upload.tsx
@@ -1,14 +1,11 @@
-import { useCallback, useRef, useState } from "react";
-import { Alert, Text, ScrollView, Pressable, StyleSheet, View, useColorScheme } from "react-native";
+import { useCallback } from "react";
+import { Text, ScrollView, Pressable, StyleSheet, View, useColorScheme } from "react-native";
 import { Stack, useRouter, useLocalSearchParams } from "expo-router";
 import { Image } from "expo-image";
 import Animated, { FadeIn } from "react-native-reanimated";
 import * as Haptics from "expo-haptics";
 import { useImagePicker, type PickedImage } from "@/hooks/useImagePicker";
 import { PermissionModal } from "@/components/PermissionModal";
-import { ProcessingOverlay } from "@/components/ProcessingOverlay";
-import { resizeForAnalysis } from "@/utils/imageResize";
-import { setAnalysisResult } from "@/utils/analysisStore";
 import { WizardProgress } from "@/components/WizardProgress";
 import { useColors } from "@/utils/theme";
 
@@ -16,15 +13,9 @@ export default function Upload() {
   const router = useRouter();
   const { wizard } = useLocalSearchParams<{ wizard?: string }>();
   const isWizardMode = wizard === 'true';
-  const abortRef = useRef<AbortController | null>(null);
-  const [image, setImage] = useState<PickedImage | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const colors = useColors();
   const colorScheme = useColorScheme();
   const isDark = colorScheme === "dark";
-
-  // Derived: processing whenever an image has been picked
-  const isProcessing = image != null;
 
   const handleSkip = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -32,72 +23,9 @@ export default function Upload() {
     router.push(`/custom${wizardParam}`);
   };
 
-  const analyzeImage = useCallback(async (picked: PickedImage) => {
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    setImage(picked);
-    setError(null);
-
-    const customRoute = isWizardMode
-      ? '/custom?initialPanels=true&wizard=true'
-      : '/custom?initialPanels=true';
-
-    const handleAnalysisError = (message: string) => {
-      console.error("Analysis failed:", message);
-      setImage(null);
-      setError(message);
-      Alert.alert(
-        "Analysis Failed",
-        `Could not analyze the image: ${message}. Please try again.`,
-      );
-    };
-
-    try {
-      const resized = await resizeForAnalysis(picked.uri);
-
-      const response = await fetch("/api/analyze", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          image: resized.base64,
-          mimeType: resized.mimeType,
-        }),
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        let errorMessage = `Server error: ${response.status}`;
-        try {
-          const body = await response.json();
-          if (body.error) {
-            errorMessage = body.error;
-          }
-        } catch {
-          // ignore JSON parse error
-        }
-        handleAnalysisError(errorMessage);
-        return;
-      }
-
-      const result = await response.json();
-
-      setAnalysisResult({
-        panels: result.panels,
-        imageWidth: resized.width,
-        imageHeight: resized.height,
-      });
-
-      router.replace(customRoute);
-    } catch (err: unknown) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      let message = "Unknown error";
-      if (err instanceof Error) {
-        message = err.message;
-      }
-      handleAnalysisError(message);
-    }
+  const onImageSelected = useCallback((picked: PickedImage) => {
+    const wizardParam = isWizardMode ? '&wizard=true' : '';
+    router.push(`/analyze?imageUri=${encodeURIComponent(picked.uri)}${wizardParam}`);
   }, [isWizardMode, router]);
 
   const {
@@ -106,7 +34,7 @@ export default function Upload() {
     modalState,
     handleModalAllow,
     handleModalClose,
-  } = useImagePicker(analyzeImage);
+  } = useImagePicker(onImageSelected);
 
   return (
     <>
@@ -220,10 +148,6 @@ export default function Upload() {
           onAllow={handleModalAllow}
           onClose={handleModalClose}
         />
-      )}
-
-      {isProcessing && !error && (
-        <ProcessingOverlay imageUri={image!.uri} />
       )}
     </>
   );

--- a/src/components/AnalysisPreview.tsx
+++ b/src/components/AnalysisPreview.tsx
@@ -68,9 +68,9 @@ export function AnalysisPreview({
         />
       )}
       {panels.map((panel, index) => {
-        // Center point from the AI's bounding box
-        const cx = (panel.x + panel.width / 2) * scale;
-        const cy = (panel.y + panel.height / 2) * scale;
+        // AI returns center point directly
+        const cx = panel.x * scale;
+        const cy = panel.y * scale;
         // Apply uniform size, swapping for rotated panels
         const w = (panel.rotation === 90 ? medianH : medianW) * scale;
         const h = (panel.rotation === 90 ? medianW : medianH) * scale;

--- a/src/components/AnalysisPreview.tsx
+++ b/src/components/AnalysisPreview.tsx
@@ -1,0 +1,71 @@
+import { useWindowDimensions } from "react-native";
+import {
+  Canvas,
+  Image as SkiaImage,
+  Rect,
+  useImage,
+} from "@shopify/react-native-skia";
+
+interface PanelResult {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: 0 | 90;
+  label: string;
+}
+
+interface AnalysisPreviewProps {
+  imageUri: string;
+  imageWidth: number;
+  imageHeight: number;
+  panels: PanelResult[];
+}
+
+const MAX_HEIGHT = 200;
+const HORIZONTAL_PADDING = 48;
+
+export function AnalysisPreview({
+  imageUri,
+  imageWidth,
+  imageHeight,
+  panels,
+}: AnalysisPreviewProps) {
+  const { width: screenWidth } = useWindowDimensions();
+  const image = useImage(imageUri);
+
+  const maxWidth = screenWidth - HORIZONTAL_PADDING;
+  const scaleX = maxWidth / imageWidth;
+  const scaleY = MAX_HEIGHT / imageHeight;
+  const scale = Math.min(scaleX, scaleY);
+
+  const displayWidth = imageWidth * scale;
+  const displayHeight = imageHeight * scale;
+
+  return (
+    <Canvas style={{ width: displayWidth, height: displayHeight, alignSelf: "center" }}>
+      {image && (
+        <SkiaImage
+          image={image}
+          x={0}
+          y={0}
+          width={displayWidth}
+          height={displayHeight}
+          fit="fill"
+        />
+      )}
+      {panels.map((panel, index) => (
+        <Rect
+          key={index}
+          x={panel.x * scale}
+          y={panel.y * scale}
+          width={panel.width * scale}
+          height={panel.height * scale}
+          color="red"
+          style="stroke"
+          strokeWidth={2}
+        />
+      ))}
+    </Canvas>
+  );
+}

--- a/src/utils/__tests__/geocoding.test.ts
+++ b/src/utils/__tests__/geocoding.test.ts
@@ -5,8 +5,7 @@ import { searchCity } from "../geocoding";
 const mockFetch = mock(() => Promise.resolve(new Response("[]")));
 
 beforeEach(() => {
-  // @ts-expect-error - replacing global fetch with mock
-  globalThis.fetch = mockFetch;
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
   mockFetch.mockReset();
 });
 
@@ -53,7 +52,7 @@ describe("searchCity", () => {
     await searchCity("Berlin");
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    const url = mockFetch.mock.calls[0][0] as string;
+    const url = (mockFetch.mock.calls[0] as unknown[])[0] as string;
     expect(url).toContain("q=Berlin");
     expect(url).toContain("format=json");
     expect(url).toContain("limit=5");
@@ -66,7 +65,7 @@ describe("searchCity", () => {
 
     await searchCity("Tokyo");
 
-    const options = mockFetch.mock.calls[0][1] as RequestInit;
+    const options = (mockFetch.mock.calls[0] as unknown[])[1] as RequestInit;
     expect(options.headers).toBeDefined();
     const headers = options.headers as Record<string, string>;
     expect(headers["User-Agent"]).toBe("SolarArrayLayoutApp/1.0");

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -33,9 +33,9 @@ resource "aws_iam_access_key" "bedrock_api" {
   user = aws_iam_user.bedrock_api.name
 }
 
-# Minimal policy: only InvokeModel on Claude models
+# Minimal policy: only InvokeModel on allowed models
 resource "aws_iam_user_policy" "bedrock_invoke" {
-  name = "bedrock-invoke-claude"
+  name = "bedrock-invoke-models"
   user = aws_iam_user.bedrock_api.name
 
   policy = jsonencode({
@@ -47,9 +47,22 @@ resource "aws_iam_user_policy" "bedrock_invoke" {
         "bedrock:InvokeModelWithResponseStream"
       ]
       Resource = [
+        # Anthropic Claude
         "arn:aws:bedrock:*::foundation-model/anthropic.claude-*",
         "arn:aws:bedrock:*::inference-profile/us.anthropic.claude-*",
-        "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-*"
+        "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-*",
+        # Amazon Nova
+        "arn:aws:bedrock:*::foundation-model/amazon.nova-*",
+        "arn:aws:bedrock:*::inference-profile/us.amazon.nova-*",
+        "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/us.amazon.nova-*",
+        # Meta Llama
+        "arn:aws:bedrock:*::foundation-model/meta.llama*",
+        "arn:aws:bedrock:*::inference-profile/us.meta.llama*",
+        "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/us.meta.llama*",
+        # Mistral
+        "arn:aws:bedrock:*::foundation-model/mistral.*",
+        "arn:aws:bedrock:*::inference-profile/us.mistral.*",
+        "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/us.mistral.*"
       ]
     }]
   })

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,13 +40,14 @@ resource "aws_iam_user_policy" "bedrock_invoke" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Action = [
-        "bedrock:InvokeModel",
-        "bedrock:InvokeModelWithResponseStream"
-      ]
-      Resource = [
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream"
+        ]
+        Resource = [
         # Anthropic Claude
         "arn:aws:bedrock:*::foundation-model/anthropic.claude-*",
         "arn:aws:bedrock:*::inference-profile/us.anthropic.claude-*",
@@ -64,6 +65,15 @@ resource "aws_iam_user_policy" "bedrock_invoke" {
         "arn:aws:bedrock:*::inference-profile/us.mistral.*",
         "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/us.mistral.*"
       ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "aws-marketplace:ViewSubscriptions",
+        "aws-marketplace:Subscribe",
+        "aws-marketplace:Unsubscribe"
+      ]
+      Resource = "*"
     }]
   })
 }


### PR DESCRIPTION
## Summary

- **Multi-model AI comparison**: Split upload flow into separate upload and analyze screens. Users can select from 7 AI models (Claude Sonnet/Opus, Amazon Nova, Mistral Pixtral, Meta Llama) before analyzing a solar panel photo.
- **Analysis preview**: New Skia canvas component shows detected panels as red bounding boxes overlaid on the image, with panel count, model name, and AI reasoning.
- **Grid layout from AI results**: Detected panels are organized into clean rows and columns on the canvas (instead of preserving scattered photo coordinates). Row/column clustering algorithm groups panels by Y-coordinate proximity, then lays out a centered grid with standard spacing.
- **Bun.fetch fix**: API route uses `globalThis.Bun.fetch` to bypass Metro's `fetch-nodeshim` which crashes under Bun runtime.
- **Terraform IAM expansion**: Added permissions for Amazon Nova, Meta Llama, Mistral models and AWS Marketplace subscription actions.

## Test plan

- [x] `bun test` — 74/74 unit tests pass
- [x] `tsc --noEmit` — type check clean
- [x] `npx react-doctor --verbose` — 97/100
- [x] `bun run test:maestro` — 5/5 E2E tests pass (including new `analyze-skip.yaml`)
- [x] Manual: analyze photo → verify red boxes on preview → continue → verify clean grid layout on canvas
- [ ] CI workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)